### PR TITLE
Pipe session ica yaml into yq rather than specify as an argument

### DIFF
--- a/autocompletion/helpers/_config_setup.sh
+++ b/autocompletion/helpers/_config_setup.sh
@@ -3,7 +3,7 @@ if [[ -z "${ICAV2_ACCESS_TOKEN-}" ]]; then
     --unwrapScalar \
     '
       .access-token
-    ' "${HOME}/.icav2/.session.ica.yaml"
+    ' < "${HOME}/.icav2/.session.ica.yaml"
   )"
 fi
 
@@ -13,7 +13,7 @@ if [[ -z "${ICAV2_PROJECT_ID-}" ]]; then
     --unwrapScalar \
       '
         .project-id
-      ' "${HOME}/.icav2/.session.ica.yaml"
+      ' < "${HOME}/.icav2/.session.ica.yaml"
   )"
 fi
 


### PR DESCRIPTION
When yq is installed via snap it won't read hidden files, pipe workarounds this. 

Fixes autocompletion issue https://github.com/umccr/icav2-cli-plugins/issues/57
