### PR TITLE
raise error and rename uid_format issue

### DIFF
--- a/src/plugins/subcommands/__init__.py
+++ b/src/plugins/subcommands/__init__.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
 import sys
-from argparse import ArgumentError
 
 from docopt import docopt
+from utils.errors import InvalidArgumentError
 from utils.logger import get_logger
-from utils import version
 from utils.docopt_helpers import clean_multi_args
 
 # Collect logger
@@ -31,7 +30,7 @@ class Command:
         # Confirm 'required' arguments are present and valid
         try:
             self.check_args()
-        except ArgumentError:
+        except InvalidArgumentError:
             self._help(fail=True)
 
     def get_args(self, command_argv):

--- a/src/plugins/subcommands/projectanalyses/get_input_json.py
+++ b/src/plugins/subcommands/projectanalyses/get_input_json.py
@@ -4,7 +4,7 @@
 Get input json
 """
 import json
-from argparse import ArgumentError
+from utils.errors import InvalidArgumentError
 from typing import Optional, Dict
 
 from utils.config_helpers import get_project_id
@@ -54,7 +54,7 @@ Example:
 
         if self.analysis_id is None:
             logger.error("Please specify the analysis id")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         self.project_id = get_project_id()
 

--- a/src/plugins/subcommands/projectanalyses/get_output_json.py
+++ b/src/plugins/subcommands/projectanalyses/get_output_json.py
@@ -4,7 +4,7 @@
 Get output json
 """
 import json
-from argparse import ArgumentError
+from utils.errors import InvalidArgumentError
 from typing import Optional, Dict
 
 from utils.config_helpers import get_project_id
@@ -54,7 +54,7 @@ Example:
 
         if self.analysis_id is None:
             logger.error("Please specify the analysis id")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         self.project_id = get_project_id()
 

--- a/src/plugins/subcommands/projectanalyses/get_step_logs.py
+++ b/src/plugins/subcommands/projectanalyses/get_step_logs.py
@@ -12,9 +12,10 @@ import os
 from libica.openapi.v2.model.analysis_step_logs import AnalysisStepLogs
 from libica.openapi.v2.model.create_cwl_analysis import CreateCwlAnalysis
 
-from utils import is_project_id_format
+from utils import is_uuid_format
 from utils.config_helpers import get_project_id_from_project_name, \
     get_libicav2_configuration, get_project_id
+from utils.errors import InvalidArgumentError
 
 from utils.projectanalysis_helpers import \
     get_workflow_steps, filter_analysis_steps, write_analysis_step_logs
@@ -22,7 +23,6 @@ from utils.projectanalysis_helpers import \
 from subcommands import Command
 from utils.logger import get_logger
 from pathlib import Path
-from argparse import ArgumentError
 from typing import Optional, Dict, List
 
 
@@ -87,11 +87,11 @@ Example:
         # Check analysis id is not None
         if self.analysis_id is None:
             logger.error("Must specify --analysis-id parameter")
-            raise ArgumentError
+            raise InvalidArgumentError
 
-        if not is_project_id_format(self.analysis_id):
+        if not is_uuid_format(self.analysis_id):
             logger.error(f"Got --analysis-id parameter as {self.analysis_id} but is not in UUID format")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Get analysis storage size
         self.step_name = self.args.get("--step-name", None)
@@ -100,17 +100,17 @@ Example:
         if self.step_name is None:
             logger.error("Must specify --step-name parameter, please use the cwl-ica icav2-list-analysis-steps"
                          "and use the 'name' attribute of the step youd like to see")
-            raise ArgumentError
+            raise InvalidArgumentError
         if self.step_name == "cwltool":
             self.step_name = "pipeline_runner.0"
 
         # Check not both stderr and stdout have been specified
         if self.args.get("--stderr", False) and self.args.get("--stdout", False):
             logger.error("Please specify one and only one of --stderr and --stdout")
-            raise ArgumentError
+            raise InvalidArgumentError
         if not self.args.get("--stderr", False) and not self.args.get("--stdout", False):
             logger.error("Please specify one and only one of --stderr and --stdout")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check if stderr has been specified
         if self.args.get("--stderr", False):
@@ -128,7 +128,7 @@ Example:
                 self.output_path = None
             elif not self.output_path.parent.is_dir():
                 logger.error(f"Parent of {self.output_path} does not exist, please create it first")
-                raise ArgumentError
+                raise InvalidArgumentError
 
     def get_analysis_logs(self) -> AnalysisStepLogs:
         # Get workflow steps

--- a/src/plugins/subcommands/projectanalyses/list_steps.py
+++ b/src/plugins/subcommands/projectanalyses/list_steps.py
@@ -10,15 +10,15 @@ This is entirely the wrong spot for this, but the code was already all here!
 import json
 import os
 
-from utils import is_project_id_format
+from utils import is_uuid_format
 from utils.config_helpers import get_project_id
+from utils.errors import InvalidArgumentError
 
 from utils.projectanalysis_helpers import \
     get_workflow_steps, filter_analysis_steps
 
 from subcommands import Command
 from utils.logger import get_logger
-from argparse import ArgumentError
 from typing import Optional, Dict, List
 
 
@@ -67,11 +67,11 @@ Example:
         # Check analysis id is not None
         if self.analysis_id is None:
             logger.error("Must specify analysis-id positional argument")
-            raise ArgumentError
+            raise InvalidArgumentError
 
-        if not is_project_id_format(self.analysis_id):
+        if not is_uuid_format(self.analysis_id):
             logger.error(f"Got --analysis-id parameter as {self.analysis_id} but is not in UUID format")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check if show technical steps has been specified
         if self.args.get("--show-technical-steps", False):

--- a/src/plugins/subcommands/projectdata/create_download_script.py
+++ b/src/plugins/subcommands/projectdata/create_download_script.py
@@ -7,7 +7,6 @@ encoded into a base64 script
 import json
 import shutil
 
-from argparse import ArgumentError
 import os
 import stat
 from base64 import b64encode
@@ -35,6 +34,7 @@ from utils.projectdata_helpers import check_is_directory, find_data_recursively,
     get_data_obj_from_project_id_and_path
 from utils.subprocess_handler import run_subprocess_proc
 from utils.template_helpers import get_templates_dir
+from utils.errors import InvalidArgumentError
 
 logger = get_logger()
 
@@ -134,13 +134,13 @@ Examples: icav2 projectdata create-download-script /test_data/outputs/
         data_path_arg = self.args.get("<data_path>", None)
         if data_path_arg is None:
             logger.error("Could not get arg for <data_path>")
-            raise ArgumentError
+            raise InvalidArgumentError
         self.data_path = Path(data_path_arg)
 
         # check data_path is real and accessible in project id
         if not check_is_directory(self.project_id, str(self.data_path) + "/"):
             logger.error(f"Could not find data path {self.data_path} in project '{self.project_id}'")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         self.data_id = get_data_obj_from_project_id_and_path(
             project_id=self.project_id,
@@ -151,11 +151,11 @@ Examples: icav2 projectdata create-download-script /test_data/outputs/
         name_arg = self.args.get("--name", None)
         if name_arg is None:
             logger.error("Could not get arg for --name")
-            raise ArgumentError
+            raise InvalidArgumentError
         # Check --name matches file friendly regex
         if re.fullmatch(r"[\w.\-_]+", name_arg) is None:
             logger.error("Please ensure --name argument contains only the characters 'A-Za-z0-9.-_'")
-            raise ArgumentError
+            raise InvalidArgumentError
         self.name = name_arg
 
         # Get output directory
@@ -164,7 +164,7 @@ Examples: icav2 projectdata create-download-script /test_data/outputs/
             output_directory_arg = os.getcwd()
         elif not Path(output_directory_arg).is_dir():
             logger.error(f"--output-directory specified as '{output_directory_arg}' but directory does not exist")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Get date
         self.date = datetime.utcnow()
@@ -185,11 +185,11 @@ Examples: icav2 projectdata create-download-script /test_data/outputs/
             )
         ) > 1:
             logger.error("Please specify no more than one of --public-key, --keybase-username or --keybase-team")
-            raise ArgumentError
+            raise InvalidArgumentError
         if public_key_arg is not None:
             if not Path(public_key_arg).is_file():
                 logger.error(f"--public-key value specified as '{public_key_arg}' but file does not exist")
-                raise ArgumentError
+                raise InvalidArgumentError
             self.public_key = Path(public_key_arg)
             self.is_encrypted = True
         if keybase_username_arg is not None:
@@ -214,7 +214,7 @@ Examples: icav2 projectdata create-download-script /test_data/outputs/
                 logger.error(
                     "Cannot find keybase binary but --keybase-username or --keybase-team was selected"
                 )
-                raise ArgumentError
+                raise InvalidArgumentError
 
         # Get the file regex
         file_regex_arg = self.args.get("--file-regex", None)

--- a/src/plugins/subcommands/projectdata/find.py
+++ b/src/plugins/subcommands/projectdata/find.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python3
 
-import argparse
-import logging
-from argparse import ArgumentError
-import os
 from typing import List, Optional
-import math
 import re
 
 from libica.openapi.v2.model.project_data import ProjectData
 
-from utils import is_project_id_format
+from utils import is_uuid_format
+from utils.errors import InvalidArgumentError
 from utils.config_helpers import get_project_id_from_session_file, get_project_id
 from utils.projectdata_helpers import check_is_directory, list_data_non_recursively, list_files_short, list_files_long, \
     find_data_recursively
@@ -97,7 +93,7 @@ Example: icav2 projectdata find /reference_data/
         # Check data path ends with a '/'
         if not data_path.endswith("/"):
             logger.error("data path parameter should end in a '/'")
-            raise ArgumentError
+            raise InvalidArgumentError
         self.data_path = data_path
 
         # Get project id
@@ -118,21 +114,21 @@ Example: icav2 projectdata find /reference_data/
         if min_depth_arg is not None:
             if not str(min_depth_arg).isdigit():
                 logger.error(f"Expecting a numeric value for --min-depth but got '{min_depth_arg}'")
-                raise ArgumentError
+                raise InvalidArgumentError
             self.min_depth = int(self.args.get("--min-depth"))
 
         max_depth_arg = self.args.get("--max-depth", None)
         if max_depth_arg is not None:
             if not str(max_depth_arg).isdigit():
                 logger.error(f"Expecting a numeric value for --max-depth but got '{max_depth_arg}'")
-                raise ArgumentError
+                raise InvalidArgumentError
             self.max_depth = int(self.args.get("--max-depth"))
 
         type_arg = self.args.get("--type", None)
         if type_arg is not None:
             if not str(type_arg).upper() in [ "FILE", "DIRECTORY" ]:
                 logger.error(f"Expected type arg to be one of 'FILE' or 'DIRECTORY' but got '{type_arg}'")
-                raise ArgumentError
+                raise InvalidArgumentError
             self.type = type_arg
 
         name_arg = self.args.get("--name", None)
@@ -143,7 +139,7 @@ Example: icav2 projectdata find /reference_data/
 
         creator_arg = self.args.get("--creator", None)
         if creator_arg is not None:
-            if is_project_id_format(creator_arg):
+            if is_uuid_format(creator_arg):
                 self.creator_id = creator_arg
                 self.creator_name = get_user_from_user_id(self.creator_id).username
             else:

--- a/src/plugins/subcommands/projectdata/ls.py
+++ b/src/plugins/subcommands/projectdata/ls.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python3
 
-import argparse
-import logging
-from argparse import ArgumentError
-import os
 from typing import List, Optional
-import math
 
 from libica.openapi.v2.model.project_data import ProjectData
 
-from utils.config_helpers import get_project_id_from_session_file, get_project_id
+from utils.errors import InvalidArgumentError
+from utils.config_helpers import get_project_id
 from utils.projectdata_helpers import check_is_directory, list_data_non_recursively, list_files_short, list_files_long
 from utils.logger import get_logger
-from utils.user_helpers import get_user_from_user_id
 
 from subcommands import Command
 
@@ -71,7 +66,7 @@ Example: icav2 projectdata ls /reference_data/
         # Check data path ends with a '/'
         if not data_path.endswith("/"):
             logger.error("data path parameter should end in a '/'")
-            raise ArgumentError
+            raise InvalidArgumentError
         self.data_path = data_path
 
         # Get project id

--- a/src/plugins/subcommands/projectdata/s3_sync_download.py
+++ b/src/plugins/subcommands/projectdata/s3_sync_download.py
@@ -4,9 +4,10 @@
 Use AWS sync command to download data from ICAv2
 """
 
-from argparse import ArgumentError
 from pathlib import Path
 from typing import List, Optional, Dict
+
+from utils.errors import InvalidArgumentError
 
 from subcommands import Command
 
@@ -78,7 +79,7 @@ Examples: icav2 projectdata s3-sync-download /test_data/outputs/ $HOME/outputs/
         # Check data path ends with a '/'
         if not self.data_path.endswith("/"):
             logger.error("data path parameter should end in a '/'")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         self.project_id = get_project_id()
 
@@ -102,24 +103,24 @@ Examples: icav2 projectdata s3-sync-download /test_data/outputs/ $HOME/outputs/
         if not self.download_path.parent.is_dir() and \
                 self.write_script_path is None:
             logger.error(f"Please ensure parent folder of download path parameter '{self.download_path}' exists")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check download path is not a file
         if self.download_path.is_file() and \
                 self.write_script_path is not None:
             logger.error(f"Cannot download data to {self.download_path}, file exists")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check write script path is not a folder
         if self.write_script_path is not None and self.write_script_path.is_dir():
             logger.error(f"Cannot write script to {self.write_script_path}, is a directory")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check if parent script path exists
         if self.write_script_path is not None and \
             not self.write_script_path.parent.is_dir():
             logger.error(f"Please ensure parent folder of the write-script-path parameter '{self.write_script_path}' exists")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check awsv2 is installed if write script path is not set
         if self.write_script_path is None:

--- a/src/plugins/subcommands/projectdata/s3_sync_upload.py
+++ b/src/plugins/subcommands/projectdata/s3_sync_upload.py
@@ -4,12 +4,12 @@
 Use AWS sync command to upload data to ICAv2
 """
 
-from argparse import ArgumentError
 from pathlib import Path
 from typing import List, Optional, Dict
 
 from subcommands import Command
 
+from utils.errors import InvalidArgumentError
 from utils.config_helpers import get_project_id
 from utils.projectdata_helpers import \
     get_data_obj_from_project_id_and_path, \
@@ -79,7 +79,7 @@ Examples: icav2 projectdata s3-sync-upload $HOME/test_inputs/ /test_data/inputs/
         # Check data path ends with a '/'
         if not self.data_path.endswith("/"):
             logger.error("data path parameter should end in a '/'")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         self.project_id = get_project_id()
 
@@ -95,24 +95,24 @@ Examples: icav2 projectdata s3-sync-upload $HOME/test_inputs/ /test_data/inputs/
         if not self.upload_path.is_dir() and \
                 self.write_script_path is None:
             logger.error(f"Please ensure upload path parameter '{self.upload_path}' exists")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check upload path is not a file
         if self.upload_path.is_file() and \
                 self.write_script_path is not None:
             logger.error(f"Cannot upload data to {self.data_path}, expected upload path to be a directory, not a file")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check write script path is not a folder
         if self.write_script_path is not None and self.write_script_path.is_dir():
             logger.error(f"Cannot write script to {self.write_script_path}, is a directory")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check if parent script path exists
         if self.write_script_path is not None and \
                 not self.write_script_path.parent.is_dir():
             logger.error(f"Please ensure parent folder of the write-script-path parameter '{self.write_script_path}' exists")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check awsv2 is installed if write script path is not set
         if self.write_script_path is None:

--- a/src/plugins/subcommands/projectdata/view.py
+++ b/src/plugins/subcommands/projectdata/view.py
@@ -5,11 +5,11 @@ View a file
 """
 
 import argparse
-from argparse import ArgumentError
 import os
 from subprocess import SubprocessError
 from typing import Optional
 
+from utils.errors import InvalidArgumentError
 from utils.config_helpers import get_project_id_from_session_file, get_project_id
 from utils.projectdata_helpers import check_is_file, \
     create_data_download_url, get_data_obj_from_project_id_and_path, view_in_browser, write_url_contents_to_stdout
@@ -76,7 +76,7 @@ Example: icav2 projectdata view /output_data/tiny.fastq.gz | zcat | head
         # Check data path ends with a '/'
         if self.data_path.endswith("/"):
             logger.error("view subcommand can only view files not folders")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check data path is a file
         if not check_is_file(

--- a/src/plugins/subcommands/projectpipelines/create_cwl_workflow_from_github_release.py
+++ b/src/plugins/subcommands/projectpipelines/create_cwl_workflow_from_github_release.py
@@ -10,11 +10,11 @@ Create technical tags for
 """
 import os
 import shutil
-from argparse import ArgumentError
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Optional
 
+from utils.errors import InvalidArgumentError
 from utils.config_helpers import get_project_id
 from utils.cwl_helpers import ZippedCWLWorkflow
 from utils.gh_helpers import download_zipped_workflow_from_github_release, get_release_repo_and_tag_from_release_url
@@ -131,7 +131,7 @@ Example:
         url_obj = requests.get(github_release_url_arg)
         if not url_obj.status_code == 200:
             logger.error(f"Got status code {url_obj.status_code}, reason {url_obj.reason}")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Set release url
         self.github_release_url = github_release_url_arg

--- a/src/plugins/subcommands/projectpipelines/create_cwl_workflow_from_zip.py
+++ b/src/plugins/subcommands/projectpipelines/create_cwl_workflow_from_zip.py
@@ -16,6 +16,7 @@ from tempfile import NamedTemporaryFile
 from typing import Optional, Dict
 import math
 
+from utils.errors import InvalidArgumentError
 from utils.config_helpers import get_project_id
 from utils.cwl_helpers import ZippedCWLWorkflow, generate_plot_png, generate_markdown_doc, \
     generate_standalone_html_through_pandoc
@@ -117,10 +118,10 @@ Example:
         self.zipped_workflow_path = Path(self.args.get("<zipped_workflow_path>"))
         if not self.zipped_workflow_path.is_file():
             logger.error(f"Could not access zipped workflow path {self.zipped_workflow_path}")
-            raise ArgumentError
+            raise InvalidArgumentError
         if not self.zipped_workflow_path.name.endswith(".zip"):
             logger.error(f"zipped-workflow-path parameter {self.zipped_workflow_path} does not end with '.zip'")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Check we can get project id
         self.project_id = get_project_id()

--- a/src/plugins/subcommands/projectpipelines/create_wes_input_template.py
+++ b/src/plugins/subcommands/projectpipelines/create_wes_input_template.py
@@ -8,7 +8,6 @@ Given a pipeline id or pipeline code, create a wes input template that comprises
 * engine parameters
 """
 import os
-from argparse import ArgumentError
 from fileinput import FileInput
 from tempfile import NamedTemporaryFile
 from typing import Optional, List, Dict, Tuple
@@ -18,6 +17,7 @@ from ruamel.yaml import YAML, \
 
 from pathlib import Path
 
+from utils.errors import InvalidArgumentError
 from utils.config_helpers import get_project_id
 from utils.gh_helpers import get_release_markdown_file_doc_as_html, get_inputs_template_from_html_doc, \
     get_overrides_template_from_html_doc, get_release_repo_and_tag_from_release_url
@@ -186,7 +186,7 @@ Example:
             self.user_reference = name_arg
         else:
             logger.error("Must specify one of --user-reference or --name")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Get pipeline id / code
         pipeline_id_arg = self.args.get("--pipeline-id", None)
@@ -198,7 +198,7 @@ Example:
             self.pipeline_id = get_pipeline_id_from_pipeline_code(self.project_id, pipeline_code_arg)
         else:
             logger.error("Must specify one of --pipeline-id or --pipeline-code")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Get pipeline description
         self.pipeline_description = get_pipeline_description_from_pipeline_id(self.project_id, self.pipeline_id)
@@ -217,10 +217,10 @@ Example:
         if not self.output_template_yaml_path.parent.is_dir():
             logger.error(f"Please ensure parent directory of "
                          f"--output-template-yaml-path parameter {self.output_template_yaml_path} is set")
-            raise ArgumentError
+            raise InvalidArgumentError
         if self.output_template_yaml_path.is_dir():
             logger.error(f"Cannot create file at {self.output_template_yaml_path}, is a directory")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Get output parent folder path / id (don't need to evaluate)
         output_parent_folder_id_arg = self.args.get("--output-parent-folder-id", None)

--- a/src/plugins/subcommands/projectpipelines/launch_cwl_wes.py
+++ b/src/plugins/subcommands/projectpipelines/launch_cwl_wes.py
@@ -4,7 +4,6 @@
 Launch a workflow through CWL WES
 """
 import json
-from argparse import ArgumentError
 from typing import Optional
 
 from libica.openapi.v2.model.create_cwl_analysis import CreateCwlAnalysis
@@ -13,6 +12,7 @@ from ruamel.yaml import YAML
 
 from pathlib import Path
 
+from utils.errors import InvalidArgumentError
 from utils.config_helpers import get_project_id
 from utils.logger import get_logger
 from utils.projectdata_helpers import check_is_directory, create_data_in_project
@@ -116,7 +116,7 @@ Example:
         self.launch_yaml_path = self.args.get("--launch-yaml", None)
         if self.launch_yaml_path is None:
             logger.error("Please specify launch yaml for input")
-            raise ArgumentError
+            raise InvalidArgumentError
         self.input_launch_json: ICAv2LaunchJson = self.read_launch_yaml()
 
         # Check output path for launch body
@@ -125,7 +125,7 @@ Example:
             self.create_cwl_analysis_json_output_path = Path(create_cwl_analysis_json_output_path_arg)
             if not self.create_cwl_analysis_json_output_path.parent.is_dir():
                 logger.error("Please ensure the parent directory of the --create-cwl-analysis-json-output-path parameter exists")
-                raise ArgumentError
+                raise InvalidArgumentError
             if self.create_cwl_analysis_json_output_path.is_dir():
                 logger.error(f"Cannot create file at {self.create_cwl_analysis_json_output_path} for --create-cwl-analysis-json-output-path parameter, is a directory")
                 raise IsADirectoryError
@@ -155,7 +155,7 @@ Example:
             )
         else:
             logger.error("Must specify one of --pipeline-id or --pipeline-code")
-            raise ArgumentError
+            raise InvalidArgumentError
 
         # Get the output parent folder id
         output_parent_folder_arg = self.args.get("--output-parent-folder-id", None)

--- a/src/plugins/utils/__init__.py
+++ b/src/plugins/utils/__init__.py
@@ -19,7 +19,7 @@ def sanitise_dict_keys(input_dict: Dict) -> Dict:
     return output_dict
 
 
-def is_project_id_format(project_id: str) -> bool:
+def is_uuid_format(project_id: str) -> bool:
     try:
         _ = UUID(project_id, version=4)
         return True

--- a/src/plugins/utils/errors.py
+++ b/src/plugins/utils/errors.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+"""
+Check errors
+"""
+
+
+class InvalidArgumentError(Exception):
+    """
+    The argument key or value is
+    """
+    pass
+

--- a/src/plugins/utils/projectdata_helpers.py
+++ b/src/plugins/utils/projectdata_helpers.py
@@ -22,7 +22,7 @@ from libica.openapi.v2.model.temp_credentials import TempCredentials
 from libica.openapi.v2.model.create_data import CreateData
 from libica.openapi.v2.model.project_data import ProjectData
 from libica.openapi.v2.api.project_data_api import ProjectDataApi
-from utils import is_project_id_format
+from utils import is_uuid_format
 
 from utils.config_helpers import get_libicav2_configuration, get_project_id_from_project_name
 from utils.globals import LIBICAV2_DEFAULT_PAGE_SIZE
@@ -658,7 +658,7 @@ def convert_icav2_uri_to_data_obj(uri: str) -> ProjectData:
     data_path = uri_obj.path
 
     # Get project id
-    if is_project_id_format(project_name_or_id):
+    if is_uuid_format(project_name_or_id):
         project_id = project_name_or_id
     else:
         project_id = get_project_id_from_project_name(project_name_or_id)


### PR DESCRIPTION
Use InvalidArgumentError over ArgumentError from argparse Rename is_project_id_format to is_uuid_format instead

* Fixes https://github.com/umccr/icav2-cli-plugins/issues/75
* Fixeshttps://github.com/umccr/icav2-cli-plugins/issues/74