### PR TITLE
Add gantt plot to shell function

### DIFF
--- a/shell_functions/icav2.sh
+++ b/shell_functions/icav2.sh
@@ -37,6 +37,7 @@ icav2() {
     "_projectanalyses__get-cwl-analysis-input-json_" \
     "_projectanalyses__get-cwl-analysis-output-json_" \
     "_projectanalyses__get-analysis-step-logs_" \
+    "_projectanalyses__gantt-plot_" \
     "_projectanalyses__help_" \
     "_projectanalyses__-h_" \
     "_projectanalyses__--help_" \

--- a/src/plugins/subcommands/projectanalyses/__init__.py
+++ b/src/plugins/subcommands/projectanalyses/__init__.py
@@ -25,6 +25,7 @@ Plugin Commands:
   get-cwl-analysis-output-json     Get output json for cwl analysis
   list-analysis-steps              List the steps for a cwl analysis
   get-analysis-step-logs           Get the log outputs for a cwl analysis step
+  gantt-plot                       Create a gantt-plot for analysis
 
 Flags:
   -h, --help   help for projectanalyses


### PR DESCRIPTION
Add gantt plot to list of shell functions that need to be run through python instead

Fixes #86 