### PR TITLE
Fix broken pipe error

### DIFF
--- a/src/plugins/subcommands/projectanalyses/get_step_logs.py
+++ b/src/plugins/subcommands/projectanalyses/get_step_logs.py
@@ -187,5 +187,9 @@ Example:
         )
 
         if self.output_path is None:
-            with open(output_path, 'r') as f_h:
-                print(f_h.read())
+            try:
+                with open(output_path, 'r') as f_h:
+                    print(f_h.read())
+            except BrokenPipeError:
+                # Chances are we were piped into head command
+                pass


### PR DESCRIPTION
This prevents traceback being printed when output is piped into head / tail

Resolves https://github.com/umccr/icav2-cli-plugins/issues/93