### PR TITLE
Added tenant subcommand

### DIFF
--- a/autocompletion/bash/icav2.bash
+++ b/autocompletion/bash/icav2.bash
@@ -23,7 +23,7 @@ _icav2() {
 
     0)
         __comp_current_options || return
-        __icav2_dynamic_comp 'commands' 'analysisstorages'$'\t''Analysis storages commands'$'\n''config'$'\t''Config actions'$'\n''dataformats'$'\t''Data format commands'$'\n''help'$'\t''Help about any command'$'\n''metadatamodels'$'\t''Metadata model commands'$'\n''pipelines'$'\t''Pipeline commands'$'\n''projectanalyses'$'\t''Project analyses commands'$'\n''projectdata'$'\t''Project Data commands'$'\n''projectpipelines'$'\t''Project pipeline commands'$'\n''projects'$'\t''Project commands'$'\n''projectsamples'$'\t''Project samples commands'$'\n''regions'$'\t''Region commands'$'\n''storagebundles'$'\t''Storage bundle commands'$'\n''storageconfigurations'$'\t''Storage configurations commands'$'\n''tokens'$'\t''Tokens commands'$'\n''version'$'\t''The version of this application'
+        __icav2_dynamic_comp 'commands' 'analysisstorages'$'\t''Analysis storages commands'$'\n''config'$'\t''Config actions'$'\n''dataformats'$'\t''Data format commands'$'\n''help'$'\t''Help about any command'$'\n''metadatamodels'$'\t''Metadata model commands'$'\n''pipelines'$'\t''Pipeline commands'$'\n''projectanalyses'$'\t''Project analyses commands'$'\n''projectdata'$'\t''Project Data commands'$'\n''projectpipelines'$'\t''Project pipeline commands'$'\n''projects'$'\t''Project commands'$'\n''projectsamples'$'\t''Project samples commands'$'\n''regions'$'\t''Region commands'$'\n''storagebundles'$'\t''Storage bundle commands'$'\n''storageconfigurations'$'\t''Storage configurations commands'$'\n''tenants'$'\t''Handle tenant switching'$'\n''tokens'$'\t''Tokens commands'$'\n''version'$'\t''The version of this application'
 
     ;;
     *)
@@ -944,6 +944,83 @@ _icav2() {
           list)
             __icav2_handle_options_flags
             __comp_current_options true || return # no subcmds, no params/opts
+          ;;
+        esac
+
+        ;;
+        esac
+      ;;
+      tenants)
+        __icav2_handle_options_flags
+        case $INDEX in
+
+        1)
+            __comp_current_options || return
+            __icav2_dynamic_comp 'commands' 'enter'$'\t''enter a tenant'$'\n''init'$'\t''initialise a tenant'$'\n''list'$'\t''list tenants'$'\n''set-default-project'$'\t''Set default project for a given tenant'$'\n''set-default-tenant'$'\t''Set the default tenant by running icav2 config set under the hood'
+
+        ;;
+        *)
+        # subcmds
+        case ${MYWORDS[1]} in
+          enter)
+            OPTIONS+=('--global' 'enter tenant globally')
+            __icav2_handle_options_flags
+            case ${MYWORDS[$INDEX-1]} in
+              --global)
+              ;;
+
+            esac
+            case $INDEX in
+
+            *)
+                __comp_current_options || return
+            ;;
+            esac
+          ;;
+          init)
+            __icav2_handle_options_flags
+            __comp_current_options true || return # no subcmds, no params/opts
+          ;;
+          list)
+            __icav2_handle_options_flags
+            __comp_current_options true || return # no subcmds, no params/opts
+          ;;
+          set-default-project)
+            OPTIONS+=('--project_name' 'Name of project')
+            __icav2_handle_options_flags
+            case ${MYWORDS[$INDEX-1]} in
+              --project_name)
+              ;;
+
+            esac
+            case $INDEX in
+              2)
+                  __comp_current_options || return
+                    _icav2_tenants_set-default-project_param_tenant_name_completion
+              ;;
+
+
+            *)
+                __comp_current_options || return
+            ;;
+            esac
+          ;;
+          set-default-tenant)
+            __icav2_handle_options_flags
+            case ${MYWORDS[$INDEX-1]} in
+
+            esac
+            case $INDEX in
+              2)
+                  __comp_current_options || return
+                    _icav2_tenants_set-default-tenant_param_tenant_name_completion
+              ;;
+
+
+            *)
+                __comp_current_options || return
+            ;;
+            esac
           ;;
         esac
 
@@ -2767,6 +2844,20 @@ jq \
 ## INVOKE PROJECT FUNCTION ##
 )"
     _icav2_compreply "$param_project_name"
+}
+_icav2_tenants_set-default-project_param_tenant_name_completion() {
+    local CURRENT_WORD="${words[$cword]}"
+    local param_tenant_name="$(
+find "${ICAV2_CLI_PLUGINS_HOME}/tenants/" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;
+)"
+    _icav2_compreply "$param_tenant_name"
+}
+_icav2_tenants_set-default-tenant_param_tenant_name_completion() {
+    local CURRENT_WORD="${words[$cword]}"
+    local param_tenant_name="$(
+find "${ICAV2_CLI_PLUGINS_HOME}/tenants/" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;
+)"
+    _icav2_compreply "$param_tenant_name"
 }
 
 __icav2_dynamic_comp() {

--- a/autocompletion/helpers/_list_tenants.sh
+++ b/autocompletion/helpers/_list_tenants.sh
@@ -1,0 +1,1 @@
+find "${ICAV2_CLI_PLUGINS_HOME}/tenants/" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;

--- a/autocompletion/specs/icav2.yaml
+++ b/autocompletion/specs/icav2.yaml
@@ -459,6 +459,7 @@ subcommands:
         summary: Unlink data from a sample for a project
       update:
         summary: Update a sample for a project
+
   regions:
     summary: Region commands
     subcommands:
@@ -476,6 +477,42 @@ subcommands:
     subcommands:
       list:
         summary: list of storage configurations
+
+  tenants:
+    summary: Handle tenant switching
+    subcommands:
+      init:
+        summary: initialise a tenant
+      list:
+        summary: list tenants
+      enter:
+        summary: enter a tenant
+        options:
+          - name: global
+            summary: enter tenant globally
+      set-default-project:
+        summary: Set default project for a given tenant
+        parameters:
+          - name: tenant_name
+            summary: Name of tenant
+            type: string
+            completion:
+              command_string: |
+                __list_tenants.sh
+        options:
+          - name: project_name
+            summary: Name of project
+            type: string
+      set-default-tenant:
+        summary: Set the default tenant by running icav2 config set under the hood
+        parameters:
+          - name: tenant_name
+            summary: Name of tenant
+            type: string
+            completion:
+              command_string: |
+                __list_tenants.sh
+
   tokens:
     summary: Tokens commands
     subcommands:

--- a/autocompletion/zsh/_icav2
+++ b/autocompletion/zsh/_icav2
@@ -17,7 +17,7 @@ _icav2() {
 
         case $state in
         cmd1)
-            _alternative 'args:cmd2:((analysisstorages\:"Analysis storages commands" config\:"Config actions" dataformats\:"Data format commands" help\:"Help about any command" metadatamodels\:"Metadata model commands" pipelines\:"Pipeline commands" projectanalyses\:"Project analyses commands" projectdata\:"Project Data commands" projectpipelines\:"Project pipeline commands" projects\:"Project commands" projectsamples\:"Project samples commands" regions\:"Region commands" storagebundles\:"Storage bundle commands" storageconfigurations\:"Storage configurations commands" tokens\:"Tokens commands" version\:"The version of this application"))'
+            _alternative 'args:cmd2:((analysisstorages\:"Analysis storages commands" config\:"Config actions" dataformats\:"Data format commands" help\:"Help about any command" metadatamodels\:"Metadata model commands" pipelines\:"Pipeline commands" projectanalyses\:"Project analyses commands" projectdata\:"Project Data commands" projectpipelines\:"Project pipeline commands" projects\:"Project commands" projectsamples\:"Project samples commands" regions\:"Region commands" storagebundles\:"Storage bundle commands" storageconfigurations\:"Storage configurations commands" tenants\:"Handle tenant switching" tokens\:"Tokens commands" version\:"The version of this application"))'
         ;;
 
         args)
@@ -1375,6 +1375,103 @@ _icav2_projects_enter_param_project_name_completion
                             '-h[Show command help]' \
                             && ret=0
 
+
+                    ;;
+                    esac
+
+                ;;
+
+                esac
+            ;;
+            tenants)
+
+                # ---- Command: tenants
+                _arguments -s -C \
+                    '1: :->cmd1' \
+                    '2: :->cmd2' \
+                    '*: :->args' \
+                    && ret=0
+
+
+                case $state in
+                cmd2)
+                    _alternative 'args:cmd3:((enter\:"enter a tenant" init\:"initialise a tenant" list\:"list tenants" set-default-project\:"Set default project for a given tenant" set-default-tenant\:"Set the default tenant by running icav2 config set under the hood"))'
+                ;;
+
+                args)
+                    case $line[2] in
+                    enter)
+
+                        # ---- Command: tenants enter
+                        _arguments -s -C \
+                            '1: :->cmd1' \
+                            '2: :->cmd2' \
+                            '--help[Show command help]' \
+                            '-h[Show command help]' \
+                            '--global[enter tenant globally]:global' \
+                            && ret=0
+
+
+                    ;;
+                    init)
+
+                        # ---- Command: tenants init
+                        _arguments -s -C \
+                            '1: :->cmd1' \
+                            '2: :->cmd2' \
+                            '--help[Show command help]' \
+                            '-h[Show command help]' \
+                            && ret=0
+
+
+                    ;;
+                    list)
+
+                        # ---- Command: tenants list
+                        _arguments -s -C \
+                            '1: :->cmd1' \
+                            '2: :->cmd2' \
+                            '--help[Show command help]' \
+                            '-h[Show command help]' \
+                            && ret=0
+
+
+                    ;;
+                    set-default-project)
+
+                        # ---- Command: tenants set-default-project
+                        _arguments -s -C \
+                            '1: :->cmd1' \
+                            '2: :->cmd2' \
+                            '3: :->tenant_name' \
+                            '--help[Show command help]' \
+                            '-h[Show command help]' \
+                            '--project_name[Name of project]:project_name' \
+                            && ret=0
+
+                        case $state in
+                        tenant_name)
+_icav2_tenants_set-default-project_param_tenant_name_completion
+                        ;;
+                        esac
+
+                    ;;
+                    set-default-tenant)
+
+                        # ---- Command: tenants set-default-tenant
+                        _arguments -s -C \
+                            '1: :->cmd1' \
+                            '2: :->cmd2' \
+                            '3: :->tenant_name' \
+                            '--help[Show command help]' \
+                            '-h[Show command help]' \
+                            && ret=0
+
+                        case $state in
+                        tenant_name)
+_icav2_tenants_set-default-tenant_param_tenant_name_completion
+                        ;;
+                        esac
 
                     ;;
                     esac
@@ -3252,6 +3349,24 @@ jq \
 
  ) )
     compadd -X "project_name:" $__dynamic_completion
+}
+_icav2_tenants_set-default-project_param_tenant_name_completion() {
+    local __dynamic_completion
+    local CURRENT_WORD="$words[CURRENT]"
+    IFS=$'\n' __dynamic_completion=( $( 
+find "${ICAV2_CLI_PLUGINS_HOME}/tenants/" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;
+
+ ) )
+    compadd -X "tenant_name:" $__dynamic_completion
+}
+_icav2_tenants_set-default-tenant_param_tenant_name_completion() {
+    local __dynamic_completion
+    local CURRENT_WORD="$words[CURRENT]"
+    IFS=$'\n' __dynamic_completion=( $( 
+find "${ICAV2_CLI_PLUGINS_HOME}/tenants/" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;
+
+ ) )
+    compadd -X "tenant_name:" $__dynamic_completion
 }
 
 __icav2_dynamic_comp() {

--- a/shell_functions/icav2.sh
+++ b/shell_functions/icav2.sh
@@ -15,12 +15,14 @@ icav2() {
 
   plugin_subfunctions_array=( \
     "_projects__enter_"
+    "_tenants__enter_"
   )
 
   plugin_subcommands_top_only_array=( \
     "_projectdata" \
     "_projectanalyses" \
     "_projectpipelines" \
+    "_tenants" \
   )
 
   plugin_subcommands_array=( \
@@ -48,6 +50,13 @@ icav2() {
     "_projectpipelines__help_"
     "_projectpipelines__-h_" \
     "_projectpipelines__--help_" \
+    "_tenants__help_" \
+    "_tenants__-h_" \
+    "_tenants__--help_" \
+    "_tenants__init_" \
+    "_tenants__list_" \
+    "_tenants__set-default-project_" \
+    "_tenants__set-default-tenant_" \
   )
 
   # Check env var is set

--- a/shell_functions/icav2__plugins__cli__tenants__enter.sh
+++ b/shell_functions/icav2__plugins__cli__tenants__enter.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+
+# This file is to be sourced
+# The function below changes the ICAV2_ACCESS_TOKEN environment variable... maybe
+
+_icav2__plugins__cli__tenants__enter(){
+  : '
+  Given a tenant name, collect the api key from ~/.icav2-plugins/tenants/<tenant_name>/config.yaml.
+  Check if the --global parameter was set, in which case, just run icav2 config set
+  '
+
+  __icav2__get_base64_binary(){
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+      echo "gbase64"
+    else
+      echo "base64"
+    fi
+  }
+
+  __icav2__get_sed_binary(){
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+      echo "gsed"
+    else
+      echo "sed"
+    fi
+  }
+
+  __icav2__get_date_binary(){
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+      echo "gdate"
+    else
+      echo "date"
+    fi
+  }
+
+  __icav2__tenants__enter_print_help() {
+    echo "
+Usage: icav2 tenants enter [tenant_name] [--global] [--help]
+This command sets the project context for future commands by updating
+the ICAV2_ACCESS_TOKEN env var.
+
+If you wish to set this as the default tenant globally, please
+use the --global parameter. This will recreate the config.yaml inside ~/.icav2/ directory by
+running icav2 config set
+
+Example:
+  icav2 tenants enter umccr-beta
+
+Parameters:
+  -g, --global set tenant context globally
+  -h, --help   help for enter
+"
+  }
+
+  __icav2__create_token_from_api_key() {
+    curl --fail --silent --location --show-error \
+      --request 'POST' \
+      --url "https://ica.illumina.com/ica/rest/api/tokens" \
+      --header "Accept: application/vnd.illumina.v3+json" \
+      --header "X-API-Key: $1" \
+      -d '' |
+    jq --raw-output \
+      '.token'
+  }
+
+  __icav2__get_epoch_expiry() {
+    local access_token="$1"
+    echo "${access_token}" | \
+      "$(__icav2__get_sed_binary)" -r 's/^(\S+)\.(\S+)\.(\S+)$/\2/' | \
+      ( "$(__icav2__get_base64_binary)" --decode 2>/dev/null || true ) | \
+    jq --raw-output \
+      '.exp'
+  }
+
+  __icav2__get_seconds_to_expiry() {
+    local expiry_epoch="$1"
+    bc <<< "${expiry_epoch} - $("$(__icav2__get_date_binary)" +%s)"
+  }
+
+  __icav2__check_token_expiry() {
+      # Inputs
+      local access_token="$1"
+      local SECONDS_PER_HOUR=3600
+
+      # local vars
+      local epoch_expiry
+      local seconds_to_expiry
+
+      # Get the JWT token expiry time
+      epoch_expiry="$(__icav2__get_epoch_expiry "${access_token}")"
+
+      # Compare expiry to current time
+      seconds_to_expiry="$(__icav2__get_seconds_to_expiry "${epoch_expiry}")"
+
+      # Check token expiry
+      if [[ "${seconds_to_expiry}" -le 0 || "${seconds_to_expiry}" -le "${SECONDS_PER_HOUR}" ]]; then
+        # Token has expired OR is about to expire
+        return 1
+      fi
+  }
+
+  # Initialise interal vars
+  local global
+  local tenant_name
+  local x_api_key
+  local access_token
+  local project_id
+
+  global="false"
+  tenant_name=""
+  x_api_key=""
+  access_token=""
+  project_id=""
+
+  # Get args from command line
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -g | --global)
+        global="true"
+        ;;
+      -h | --help)
+        __icav2__tenants__enter_print_help
+        return 0
+        ;;
+      *)
+        # If name is already been set then we have the wrong command line entry
+        if [[ -n "${tenant_name}" ]]; then
+          echo "Got too many values for tenant. If your tenant name has spaces, please quote your inputs" 1>&2
+          __icav2__tenants__enter_print_help 1>&2
+          return 1
+        fi
+        tenant_name="$1"
+      ;;
+    esac
+    shift 1
+  done
+
+  ## Check name was defined
+  if [[ -z "${tenant_name}" ]]; then
+    __icav2__tenants__enter_print_help 1>&2
+    return 1
+  fi
+
+  # Check the ICAV2_CLI_PLUGINS_HOME env var has been set
+  if [[ -z "${ICAV2_CLI_PLUGINS_HOME-}" ]]; then
+    echo "Could not get the env var ICAV2_CLI_PLUGINS_HOME" 1>&2
+    echo "Please ensure you have added the icav2 cli plugins source chunk to your rc file"
+    exit 1
+  fi
+
+  # Check the tenant directory for this tenant id
+  if [[ ! -d "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}" ]]; then
+    echo "Could not find the tenant '${tenant_name}'" 1>&2
+    echo "Please run 'icav2 tenants list' to view the list of available tenants or alternatively run 'icav2 tenants init \"${tenant_name}\"' to initialise this tenant" 1>&2
+    exit 1
+  fi
+
+  # Check the config yaml exists
+  if [[ ! -r "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/config.yaml" ]]; then
+    echo "Could not read '${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/config.yaml' please re-initialise this tenant with 'icav2 tenants init \"${tenant_name}\"'" 1>&2
+    exit 1
+  fi
+
+  # Read config
+  x_api_key="$( \
+    yq \
+      --unwrapScalar \
+      '.x-api-key' \
+      < "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/config.yaml" \
+  )"
+
+  # Get the access token from .session.ica.yaml
+  if [[ -r "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml" ]]; then
+    if ! access_token="$( \
+      yq '.access-token' < "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml"
+    )"; then
+      access_token=""
+    else
+      echo "Collected access_token token from tenant session yaml" 1>&2
+    fi
+  fi
+
+  if [[ -z "${access_token}" || "${access_token}" == "null" ]] || ! __icav2__check_token_expiry "${access_token}"; then
+    # Create token from API key
+    # Check the api key
+    if [[ -z "${x_api_key}" || "${x_api_key}" == "null" ]]; then
+      echo "Could not get the api key from '${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/config.yaml'" 1>&2
+      exit 1
+    fi
+
+    # Create the token from the api key
+    echo "Creating new access token from api-key in tenant config yaml" 1>&2
+    if ! access_token="$( \
+      __icav2__create_token_from_api_key "${x_api_key}"
+    )"; then
+      echo "Failed to create access token from api-key in '${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/config.yaml'" 1>&2
+      exit 1
+    fi
+
+    echo "Successfully created new access token" 1>&2
+    if [[ -r "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml" ]]; then
+      access_token="${access_token}" \
+      yq --unwrapScalar \
+        '.access-token=env(access_token)' < "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml" \
+        > "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml.tmp"
+        mv "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml.tmp" \
+          "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml"
+    else
+      access_token="${access_token}" \
+      yq --null-input --unwrapScalar \
+        '.access-token=env(access_token)' > "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml.tmp"
+      mv "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml.tmp" \
+         "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml"
+    fi
+  fi
+
+  # Export access token
+  export ICAV2_ACCESS_TOKEN="${access_token}"
+
+  # Check if global is specified
+  if [[ "${global}" == "true" ]]; then
+    echo "--global specified Setting '${tenant_name}' as tenant globally" 1>&2
+    echo "${HOME}/.icav2/config.yaml will be updated with api key for tenant name" 1>&2
+    "${ICAV2_CLI_PLUGINS_HOME}/pyenv/bin/python" "${ICAV2_CLI_PLUGINS_HOME}/plugins/bin/icav2-cli-plugins.py" \
+      "tenants" "set-default-tenant" "${tenant_name}"
+  fi
+
+  # Get project id from tenant session yaml
+  project_id="$( \
+    yq --unwrapScalar '.project-id' < "${ICAV2_CLI_PLUGINS_HOME}/tenants/${tenant_name}/.session.ica.yaml"
+  )"
+
+  # Check project id
+  if [[ -n "${ICAV2_PROJECT_ID-}" ]]; then
+    echo "ICAV2_PROJECT_ID is set checking if project id is in tenant '${tenant_name}'" 1>&2
+    if ! \
+      curl --fail --location --silent \
+        --request "GET" \
+        --header 'Accept: application/vnd.illumina.v3+json' \
+        --header "Authorization: Bearer ${ICAV2_ACCESS_TOKEN}" \
+        --url "https://ica.illumina.com/ica/rest/api/projects/${ICAV2_PROJECT_ID}"; then
+      echo "Project ID '${ICAV2_PROJECT_ID}' is not in tenant '${tenant_name}'" 1>&2
+      if [[ -z "${project_id}" || "${project_id}" == "null" ]]; then
+        echo "No project id set in session yaml" 1>&2
+        echo "Unsetting ICAV2_PROJECT_ID env var" 1>&2
+        unset ICAV2_PROJECT_ID
+      else
+        echo "Project ID found in session yaml" 1>&2
+        echo "Setting ICAV2_PROJECT_ID env var to '${project_id}'" 1>&2
+        export ICAV2_PROJECT_ID="${project_id}"
+      fi
+    fi
+  else
+    if [[ -z "${project_id}" || "${project_id}" == "null" ]]; then
+        echo "No project id set in session yaml for tenant '${tenant_name}' so not in a project" 1>&2
+        echo "Please run 'icav2 projects enter <project-name>' to enter a project" 1>&2
+    else
+        echo "Project ID found in session yaml for tenant '${tenant_name}'" 1>&2
+        echo "Setting ICAV2_PROJECT_ID env var to '${project_id}'" 1>&2
+        export ICAV2_PROJECT_ID="${project_id}"
+    fi
+  fi
+
+  # Done
+}

--- a/src/plugins/requirements.txt
+++ b/src/plugins/requirements.txt
@@ -19,3 +19,5 @@ pypandoc==1.10
 pypandoc_binary==1.10
 humanfriendly==10.0
 matplotlib==3.7.1
+invoke==2.0.0
+fabric==3.0.0

--- a/src/plugins/subcommands/projectpipelines/__init__.py
+++ b/src/plugins/subcommands/projectpipelines/__init__.py
@@ -46,7 +46,7 @@ Use "icav2 projectpipelines [command] --help" for more information about a comma
 
         if cmd == "create-cwl-workflow-from-zip":
             from subcommands.projectpipelines.create_cwl_workflow_from_zip import ProjectDataCreateCWLWorkflow as subcommand
-        if cmd == "create-cwl-workflow-from-github-release":
+        elif cmd == "create-cwl-workflow-from-github-release":
             from subcommands.projectpipelines.create_cwl_workflow_from_github_release import ProjectDataCreateCWLWorkflowFromGitHubRelease as subcommand
         elif cmd == "create-cwl-wes-input-template":
             from subcommands.projectpipelines.create_wes_input_template import ProjectDataCreateWESInputTemplate as subcommand

--- a/src/plugins/subcommands/tenants/__init__.py
+++ b/src/plugins/subcommands/tenants/__init__.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+"""
+Tenants
+"""
+
+from subcommands import SuperCommand
+import sys
+
+
+class Tenants(SuperCommand):
+    """
+Usage:
+  icav2 tenants <command> <args...>
+
+Plugin Commands:
+    init                 Initialise a tenant and provide an API Key used for that tenant
+    enter                Enter a tenant (updates users ICAV2_ACCESS_TOKEN env var)
+    list                 List available tenants to enter
+    set-default-project  Set the default project for a given tenant
+    set-default-tenant   Set the default tenant
+
+Flags:
+  -h, --help   help for tenants
+
+Global Flags:
+  -t, --access-token string    JWT used to call rest service
+  -o, --output-format string   output format (default "table")
+  -s, --server-url string      server url to direct commands
+  -k, --x-api-key string       api key used to call rest service
+
+Use "icav2 tenants [command] --help" for more information about a command.
+    """
+
+    def __init__(self, command_argv):
+        super().__init__(command_argv)
+
+    def get_subcommand_obj(self, cmd, command_argv):
+
+        if cmd == "init":
+            from subcommands.tenants.tenants_init import TenantsInit as subcommand
+        elif cmd == "list":
+            from subcommands.tenants.tenants_list import TenantsList as subcommand
+        elif cmd == "set-default-tenant":
+            from subcommands.tenants.set_default_tenant import TenantsSetDefaultTenant as subcommand
+        elif cmd == "set-default-project":
+            from subcommands.tenants.set_default_project import TenantsSetDefaultProject as subcommand
+        else:
+            print(self.__doc__)
+            print(f"Could not find cmd \"{cmd}\". Please refer to usage above")
+            sys.exit(1)
+        # Initialise and return
+        return subcommand(command_argv)
+
+
+
+
+
+
+

--- a/src/plugins/subcommands/tenants/set_default_project.py
+++ b/src/plugins/subcommands/tenants/set_default_project.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+
+"""
+Set the project id in the tenants session ica yaml file.
+This means when tenants enter command is invoked the ICAV2_PROJECT_ID is added
+"""
+
+
+import json
+import os
+import shutil
+from collections import OrderedDict
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Optional
+from getpass import getpass
+
+from invoke import Responder
+from fabric import Connection
+
+from ruamel.yaml import YAML
+
+from utils import is_uuid_format
+from utils.errors import InvalidArgumentError
+from utils.config_helpers import get_project_id, create_access_token_from_api_key, get_jwt_token_obj, \
+    get_project_name_from_project_id_curl, get_project_id_from_project_name_curl
+from utils.cwl_helpers import ZippedCWLWorkflow
+from utils.gh_helpers import download_zipped_workflow_from_github_release, get_release_repo_and_tag_from_release_url
+from utils.globals import ICAV2_DEFAULT_ANALYSIS_STORAGE_SIZE, ICAv2AnalysisStorageSize, ICAV2_ACCESS_TOKEN_AUDIENCE
+from utils.logger import get_logger
+from utils.plugin_helpers import get_plugins_directory, get_tenants_directory
+from utils.projectpipeline_helpers import get_analysis_storage_id_from_analysis_storage_size, create_params_xml
+import requests
+
+from urllib.parse import unquote
+
+from subcommands import Command
+
+logger = get_logger()
+
+
+class TenantsSetDefaultProject(Command):
+    """Usage:
+    icav2 tenants set-default-project help
+    icav2 tenants set-default-project <tenant_name>
+                                      (--project-name <project_name)
+
+Description:
+    Given a tenant name and project name parameter, set the project in the tenants session ica yaml file.
+    This means ICAV2_PROJECT_ID env var is added when icav2 tenants enter is used.
+
+Options:
+    --project-name <project_name>    Required
+
+Environment variables:
+    ICAV2_BASE_URL           Optional, default set as https://ica.illumina.com/ica/rest
+
+Example:
+    icav2 tenants set-default-project umccr-beta --project-name playground_v2
+    """
+
+    def __init__(self, command_argv):
+        # The tenant name provided by the user
+        self.tenant_name: Optional[str] = None
+        self.tenant_path: Optional[Path] = None
+        self.tenant_config_file: Optional[Path] = None
+        self.tenant_session_file: Optional[Path] = None
+        self.tenant_session_yaml_object: Optional[OrderedDict] = None
+
+        self.tenant_api_key: Optional[str] = None
+        self.tenant_access_token: Optional[str] = None
+
+        self.project_id: Optional[str] = None
+
+        # Server url
+        self.server_url: Optional[str] = "ica.illumina.com"
+
+        # Store the tenant namespace and id in the configuration yaml
+        self.x_api_key: Optional[str] = None
+        self.current_config_yaml_object: Optional[OrderedDict] = None
+
+        super().__init__(command_argv)
+
+    def __call__(self):
+        # Update the tenant session config to have project_id as the project-id attribute
+        self.tenant_session_yaml_object["project-id"] = self.project_id
+
+        self.write_session_file()
+
+    def check_args(self):
+        # Check the tenant name arg exists
+        tenant_name_arg = self.args.get("<tenant_name>", None)
+        if tenant_name_arg is None:
+            logger.error("Could not get arg <tenant_name>")
+            raise InvalidArgumentError
+
+        self.tenant_name = tenant_name_arg
+
+        # Check the tenant directory
+        self.tenant_path = get_tenants_directory() / self.tenant_name
+
+        if not self.tenant_path.is_dir():
+            logger.error(f"Could not find tenant {self.tenant_name}, have you run 'icav2 tenants init \"{self.tenant_name}\"'")
+
+        # Set the tenant session and config files
+        self.tenant_config_file = self.tenant_path / "config.yaml"
+        self.tenant_session_file = self.tenant_path / ".session.ica.yaml"
+
+        if self.tenant_session_file.is_file():
+            self.read_tenant_session_file()
+        else:
+            self.tenant_session_yaml_object = {}
+
+        # Get the project name parameter
+        project_name_arg = self.args.get("--project-name", None)
+        if project_name_arg is None:
+            logger.error("Please specify project name argument")
+            raise InvalidArgumentError
+
+        # Collect tenant api key
+        self.tenant_api_key = self.get_tenant_api_key()
+
+        # Create access token from api key
+        self.tenant_access_token = create_access_token_from_api_key(self.tenant_api_key)
+
+        # Check project
+        if is_uuid_format(project_name_arg):
+            # Check project id is in tenant
+            self.project_id = project_name_arg
+        else:
+            # Get project id from project name
+            self.project_id = get_project_id_from_project_name_curl(project_name_arg, self.tenant_access_token)
+
+    def get_tenant_api_key(self) -> str:
+        """
+        Get the tenant api key
+        Returns:
+
+        """
+        yaml = YAML()
+
+        with open(self.tenant_config_file, "r") as file_h:
+            return yaml.load(file_h).get("x-api-key")
+
+    def read_tenant_session_file(self):
+        """
+        Read the tenant config file
+        Returns:
+
+        """
+        yaml = YAML()
+
+        with open(self.tenant_session_file, "r") as file_h:
+            self.tenant_session_yaml_object = yaml.load(file_h)
+
+    def write_session_file(self):
+        """
+        Write the session file to update the access token
+        Returns:
+
+        """
+
+        yaml = YAML()
+
+        with open(self.tenant_session_file, "w") as file_h:
+            yaml.dump(self.tenant_session_yaml_object, file_h)

--- a/src/plugins/subcommands/tenants/set_default_tenant.py
+++ b/src/plugins/subcommands/tenants/set_default_tenant.py
@@ -86,7 +86,16 @@ Example:
     def __call__(self):
         # Collect the api key from the tenant config file
         self.read_tenant_config()
-        self.read_current_config()
+
+        if self.current_config_path.is_file():
+            self.read_current_config()
+        else:
+            self.current_config_yaml_object = {
+                "server-url": "ica.illumina.com",
+                "x-api-key": None,
+                "output-format": None,
+                "colormode": None
+            }
 
         # Fill out prompts
         self.fill_prompts()
@@ -151,20 +160,38 @@ Example:
             response=self.current_config_yaml_object.get("server-url") + "\n"
         )
 
-        icav2_config_set_api_key = Responder(
-            pattern="API key \(press enter to keep the current one\) :",
-            response=self.x_api_key + "\n"
-        )
+        if self.current_config_yaml_object.get("x-api-key") is not None:
+            icav2_config_set_api_key = Responder(
+                pattern="API key \(press enter to keep the current one\) :",
+                response=self.x_api_key + "\n"
+            )
+        else:
+            icav2_config_set_api_key = Responder(
+                pattern="API key :",
+                response=self.x_api_key + "\n"
+            )
 
-        icav2_config_set_output_format = Responder(
-            pattern=f"output-format \[{self.current_config_yaml_object.get('output-format')}\]:",
-            response=self.current_config_yaml_object.get("output-format") + "\n"
-        )
+        if self.current_config_yaml_object.get("output-format") is not None:
+            icav2_config_set_output_format = Responder(
+                pattern=f"output-format \[{self.current_config_yaml_object.get('output-format')}\]:",
+                response=self.current_config_yaml_object.get("output-format") + "\n"
+            )
+        else:
+            icav2_config_set_output_format = Responder(
+                pattern=f"output-format \(allowed values table,yaml,json defaults to table\) :",
+                response="\n"
+            )
 
-        icav2_config_set_color_mode = Responder(
-            pattern=f"colormode \[{self.current_config_yaml_object.get('colormode')}\]:",
-            response=self.current_config_yaml_object.get("colormode") + "\n"
-        )
+        if self.current_config_yaml_object.get('colormode') is not None:
+            icav2_config_set_color_mode = Responder(
+                pattern=f"colormode \[{self.current_config_yaml_object.get('colormode')}\]:",
+                response=self.current_config_yaml_object.get("colormode") + "\n"
+            )
+        else:
+            icav2_config_set_color_mode = Responder(
+                pattern="colormode \(allowed values none,dark,light defaults to none\) :",
+                response="\n"
+            )
 
         run(
             "icav2 config set",

--- a/src/plugins/subcommands/tenants/set_default_tenant.py
+++ b/src/plugins/subcommands/tenants/set_default_tenant.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+
+"""
+Update the users default config.yaml under ~/.icav2/config.yaml
+
+Reads the users config.yaml under ~/.icav2-cli-plugins/tenants/<tenant_name>/config.yaml
+
+Then runs icav2 config set and auto fills the prompts using the Fabric package
+but replaces the api-key prompt twith the api key found in ~/.icav2-cli-plugins/tenants/<tenant_name>/config.yaml
+"""
+
+
+import json
+import os
+import shutil
+from collections import OrderedDict
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Optional
+from getpass import getpass
+
+from invoke import Responder, run
+from fabric import Connection
+
+from ruamel.yaml import YAML
+
+from utils import is_uuid_format
+from utils.errors import InvalidArgumentError
+from utils.config_helpers import get_project_id, create_access_token_from_api_key, get_jwt_token_obj, \
+    get_project_name_from_project_id_curl, get_project_id_from_project_name_curl
+from utils.cwl_helpers import ZippedCWLWorkflow
+from utils.gh_helpers import download_zipped_workflow_from_github_release, get_release_repo_and_tag_from_release_url
+from utils.globals import ICAV2_DEFAULT_ANALYSIS_STORAGE_SIZE, ICAv2AnalysisStorageSize, ICAV2_ACCESS_TOKEN_AUDIENCE
+from utils.logger import get_logger
+from utils.plugin_helpers import get_tenants_directory
+from utils.projectpipeline_helpers import get_analysis_storage_id_from_analysis_storage_size, create_params_xml
+import requests
+
+from urllib.parse import unquote
+
+from subcommands import Command
+
+logger = get_logger()
+
+
+class TenantsSetDefaultTenant(Command):
+    """Usage:
+    icav2 tenants set-default-tenant help
+    icav2 tenants set-default-tenant <tenant_name>
+
+
+Description:
+    Sets a tenant initialised with tenants init as the default tenant.
+    This will update the configuration yaml under ~/.icav2/config.yaml.
+    This command will NOT update any existing environment variables such as ICAV2_ACCESS_TOKEN or ICAV2_PROJECT_ID.
+
+Options:
+
+Environment variables:
+    ICAV2_BASE_URL           Optional, default set as https://ica.illumina.com/ica/rest
+
+Example:
+    icav2 tenants set-default-tenant umccr-beta
+    """
+
+    def __init__(self, command_argv):
+        # The tenant name provided by the user
+        self.tenant_name: Optional[str] = None
+        self.tenant_path: Optional[Path] = None
+        self.tenant_config_file: Optional[Path] = None
+        self.tenant_config_yaml_object: Optional[OrderedDict] = None
+        self.tenant_session_file: Optional[Path] = None
+
+        self.current_config_path: Optional[Path] = Path.home() / ".icav2" / "config.yaml"
+        self.current_session_path: Optional[Path] = Path.home() / ".icav2" / ".session.ica.yaml"
+
+        # Server url
+        self.server_url: Optional[str] = "ica.illumina.com"
+
+        # Store the tenant namespace and id in the configuration yaml
+        self.x_api_key: Optional[str] = None
+        self.current_config_yaml_object: Optional[OrderedDict] = None
+
+        super().__init__(command_argv)
+
+    def __call__(self):
+        # Collect the api key from the tenant config file
+        self.read_tenant_config()
+        self.read_current_config()
+
+        # Fill out prompts
+        self.fill_prompts()
+
+        # Copy tenant session file
+        if self.tenant_session_file.is_file():
+            shutil.copy2(self.tenant_session_file, self.current_session_path)
+
+    def check_args(self):
+        # Check the tenant name arg exists
+        tenant_name_arg = self.args.get("<tenant_name>", None)
+        if tenant_name_arg is None:
+            logger.error("Could not get arg <tenant_name>")
+            raise InvalidArgumentError
+
+        self.tenant_name = tenant_name_arg
+
+        # Check the tenant directory
+        self.tenant_path = get_tenants_directory() / self.tenant_name
+
+        if not self.tenant_path.is_dir():
+            logger.error(f"Could not find tenant {self.tenant_name}, have you run 'icav2 tenants init \"{self.tenant_name}\"'")
+
+        # Set the tenant session and config files
+        self.tenant_config_file = self.tenant_path / "config.yaml"
+        self.tenant_session_file = self.tenant_path / ".session.ica.yaml"
+
+    def read_tenant_config(self):
+        """
+        Read the tenant config file
+        Returns:
+
+        """
+        yaml = YAML()
+
+        with open(self.tenant_config_file, "r") as file_h:
+            self.tenant_config_yaml_object = yaml.load(file_h)
+
+        self.server_url = self.tenant_config_yaml_object.get("server-url", None)
+        self.x_api_key = self.tenant_config_yaml_object.get("x-api-key", None)
+
+    def read_current_config(self):
+        """
+        Read the current configuration file
+        Returns:
+
+        """
+        yaml = YAML()
+
+        with open(self.current_config_path, "r") as file_h:
+            self.current_config_yaml_object = yaml.load(file_h)
+
+    def fill_prompts(self):
+        """
+        Tenant config
+        Returns:
+
+        """
+
+        icav2_config_set_server_url = Responder(
+            pattern=f"server-url \[{self.current_config_yaml_object.get('server-url')}\]:",
+            response=self.current_config_yaml_object.get("server-url") + "\n"
+        )
+
+        icav2_config_set_api_key = Responder(
+            pattern="API key \(press enter to keep the current one\) :",
+            response=self.x_api_key + "\n"
+        )
+
+        icav2_config_set_output_format = Responder(
+            pattern=f"output-format \[{self.current_config_yaml_object.get('output-format')}\]:",
+            response=self.current_config_yaml_object.get("output-format") + "\n"
+        )
+
+        icav2_config_set_color_mode = Responder(
+            pattern=f"colormode \[{self.current_config_yaml_object.get('colormode')}\]:",
+            response=self.current_config_yaml_object.get("colormode") + "\n"
+        )
+
+        run(
+            "icav2 config set",
+            pty=True,
+            watchers=[
+                icav2_config_set_server_url,
+                icav2_config_set_api_key,
+                icav2_config_set_output_format,
+                icav2_config_set_color_mode
+            ],
+            hide='out'
+        )

--- a/src/plugins/subcommands/tenants/tenants_init.py
+++ b/src/plugins/subcommands/tenants/tenants_init.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+"""
+Initialise a tenant from an api key
+"""
+
+import json
+import os
+import shutil
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Optional
+from getpass import getpass
+
+from ruamel.yaml import YAML
+
+from utils import is_uuid_format
+from utils.errors import InvalidArgumentError
+from utils.config_helpers import get_project_id, create_access_token_from_api_key, get_jwt_token_obj, \
+    get_project_name_from_project_id_curl, get_project_id_from_project_name_curl
+from utils.cwl_helpers import ZippedCWLWorkflow
+from utils.gh_helpers import download_zipped_workflow_from_github_release, get_release_repo_and_tag_from_release_url
+from utils.globals import ICAV2_DEFAULT_ANALYSIS_STORAGE_SIZE, ICAv2AnalysisStorageSize, ICAV2_ACCESS_TOKEN_AUDIENCE
+from utils.logger import get_logger
+from utils.plugin_helpers import get_plugins_directory, get_tenants_directory
+from utils.projectpipeline_helpers import get_analysis_storage_id_from_analysis_storage_size, create_params_xml
+import requests
+
+from urllib.parse import unquote
+
+from subcommands import Command
+
+logger = get_logger()
+
+
+class TenantsInit(Command):
+    """Usage:
+    icav2 tenants init help
+    icav2 tenants init <tenant_name>
+                       [--default-project <project_name>]
+
+Description:
+    Register a tenant to the icav2 plugins home.
+    This script will prompt you to enter in an api key and will then also test generating a token
+
+Options:
+  --default-project=<project_name>   Optional, set a default project (this can be set later with icav2 tenants set-default-project
+
+Environment variables:
+    ICAV2_BASE_URL           Optional, default set as https://ica.illumina.com/ica/rest
+
+Example:
+    icav2 tenants init umccr-beta
+    """
+
+    def __init__(self, command_argv):
+        # The tenant name provided by the user
+        self.tenant_name: Optional[str] = None
+        self.tenant_path: Optional[Path] = None
+        self.tenant_config_file: Optional[Path] = None
+        self.tenant_session_file: Optional[Path] = None
+
+        # Store the tenant namespace and id in the configuration yaml
+        self.x_api_key: Optional[str] = None
+        self.access_token: Optional[str] = None
+        self.tenant_namespace: Optional[str] = None
+        self.tenant_id: Optional[str] = None
+        self.server_url: Optional[str] = "ica.illumina.com"
+
+        # Add in the project id and name
+        self.project_id: Optional[str] = None
+        self.project_name: Optional[str] = None
+
+        super().__init__(command_argv)
+
+    def __call__(self):
+        # Ask user (kindly) for the api key
+        self.x_api_key = getpass(
+            prompt=f"Please enter your api key for tenant '{self.tenant_name}' followed by the enter key: "
+        )
+
+        # Create the access token
+        self.access_token = create_access_token_from_api_key(
+            self.x_api_key
+        )
+
+        # From the access token, collect the namespace and id
+        token_obj = get_jwt_token_obj(self.access_token, ICAV2_ACCESS_TOKEN_AUDIENCE)
+        self.tenant_namespace = token_obj.get("tns")
+        self.tenant_id = token_obj.get("tid")
+
+        # Use the access token to collect the project name if set
+        if self.project_id is not None:
+            self.project_name = get_project_name_from_project_id_curl(self.project_id, self.access_token)
+        elif self.project_name is not None:
+            self.project_id = get_project_id_from_project_name_curl(self.project_name, self.access_token)
+
+        # Write out configuration yaml to file
+        self.write_session_file()
+        self.write_config_file()
+
+    def write_session_file(self):
+        yaml = YAML()
+
+        with open(self.tenant_session_file, "w") as file_h:
+            yaml.dump(
+                {
+                    "access-token": self.access_token,
+                    "project-id": self.project_id
+                },
+                file_h
+            )
+
+    def write_config_file(self):
+        yaml = YAML()
+
+        with open(self.tenant_config_file, "w") as file_h:
+            yaml.dump(
+                {
+                    "server-url": self.server_url,
+                    "x-api-key": self.x_api_key,
+                    "tid": self.tenant_id,
+                    "tns": self.tenant_namespace
+                },
+                file_h
+            )
+
+    def check_args(self):
+        # Check the tenant name arg exists
+        tenant_name_arg = self.args.get("<tenant_name>", None)
+        if tenant_name_arg is None:
+            logger.error("Could not get arg <tenant_name>")
+            raise InvalidArgumentError
+
+        self.tenant_name = tenant_name_arg
+
+        project_name_arg = self.args.get("--project-name", None)
+        if project_name_arg is not None:
+            if is_uuid_format(project_name_arg):
+                self.project_id = project_name_arg
+            else:
+                self.project_name = project_name_arg
+
+        # Create the tenant directory
+        self.tenant_path = get_tenants_directory() / self.tenant_name
+        self.tenant_path.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+        # Set the tenant session and config files
+        self.tenant_config_file = self.tenant_path / "config.yaml"
+        self.tenant_session_file = self.tenant_path / ".session.ica.yaml"
+

--- a/src/plugins/subcommands/tenants/tenants_list.py
+++ b/src/plugins/subcommands/tenants/tenants_list.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+"""
+List registered tenants for the plugin
+"""
+
+import json
+import os
+import shutil
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Optional, List, Dict
+from getpass import getpass
+
+import pandas as pd
+from ruamel.yaml import YAML
+
+from utils import is_uuid_format
+from utils.errors import InvalidArgumentError
+from utils.config_helpers import get_project_id, create_access_token_from_api_key, get_jwt_token_obj, \
+    get_project_name_from_project_id_curl, get_project_id_from_project_name_curl
+from utils.cwl_helpers import ZippedCWLWorkflow
+from utils.gh_helpers import download_zipped_workflow_from_github_release, get_release_repo_and_tag_from_release_url
+from utils.globals import ICAV2_DEFAULT_ANALYSIS_STORAGE_SIZE, ICAv2AnalysisStorageSize, ICAV2_ACCESS_TOKEN_AUDIENCE
+from utils.logger import get_logger
+from utils.plugin_helpers import get_tenants_directory
+from utils.projectpipeline_helpers import get_analysis_storage_id_from_analysis_storage_size, create_params_xml
+import requests
+
+from urllib.parse import unquote
+
+from subcommands import Command
+
+logger = get_logger()
+
+
+class TenantsList(Command):
+    """Usage:
+    icav2 tenants list help
+    icav2 tenants list
+
+Description:
+    List all tenants
+
+Options:
+
+Environment variables:
+    ICAV2_BASE_URL           Optional, default set as https://ica.illumina.com/ica/rest
+
+Example:
+    icav2 tenants list
+    """
+
+    def __init__(self, command_argv):
+        # The tenant name provided by the user
+        self.tenant_list: Optional[List] = None
+
+        super().__init__(command_argv)
+
+    def __call__(self):
+        # Ask user (kindly) for the api key
+        self.get_tenants()
+        self.print_columns()
+
+    def get_tenants(self):
+        self.tenant_list = []
+        tenants_directory = get_tenants_directory()
+
+        # Iterate through tenants
+        for tenant_dir in tenants_directory.glob("*"):
+            if not tenant_dir.is_dir():
+                continue
+            if not (tenant_dir / "config.yaml").is_file():
+                continue
+
+            tenant_config_dict = self.read_config_file(tenant_dir / "config.yaml")
+
+            self.tenant_list.append(
+                {
+                    "id": tenant_config_dict["tid"],
+                    "namespace": tenant_config_dict["tns"],
+                    "name": tenant_dir.name
+                }
+            )
+
+        if len(self.tenant_list) == 0:
+            logger.error("No tenants available, please initialise a tenant with 'icav2 tenants list'")
+            raise ValueError
+
+    def read_config_file(self, config_file) -> Dict:
+        yaml = YAML()
+
+        with open(config_file, "r") as file_h:
+            return yaml.load(file_h)
+
+    def print_columns(self):
+        pd.set_option('expand_frame_repr', False)
+        pd.set_option('display.max_columns', 999)
+
+        print(pd.DataFrame(self.tenant_list).set_index("name"))
+
+    def check_args(self):
+        pass

--- a/src/plugins/utils/cli.py
+++ b/src/plugins/utils/cli.py
@@ -27,6 +27,11 @@ Command:
     Project Pipelines
     ##########################
     projectpipelines                    Collection of subfunctions relating to creating / deploying pipelines
+
+    ######################
+    Tenants
+    #######################
+    tenants                             Collection of tenant handling scripts
 """
 
 from docopt import docopt
@@ -69,6 +74,8 @@ def _dispatch():
         from subcommands.projectdata import ProjectData as subcommand
     elif cmd == "projectpipelines":
         from subcommands.projectpipelines import ProjectPipelines as subcommand
+    elif cmd == "tenants":
+        from subcommands.tenants import Tenants as subcommand
     # NotImplemented Error
     else:
         print(__doc__)

--- a/src/plugins/utils/plugin_helpers.py
+++ b/src/plugins/utils/plugin_helpers.py
@@ -9,13 +9,17 @@ from utils.logger import get_logger
 logger = get_logger()
 
 
-def get_plugins_directory():
+def get_icav2_plugins_home_dir():
     if (icav2_plugins_dir := os.environ.get(ICAV2_CLI_PLUGINS_HOME_ENV_VAR, None)) is None:
         logger.error("Could not get env var '{ICAV2_CLI_PLUGINS_HOME_ENV_VAR}'")
         raise EnvironmentError
 
-    return Path(icav2_plugins_dir) / "plugins"
+    return Path(icav2_plugins_dir)
 
 
+def get_plugins_directory():
+    return get_icav2_plugins_home_dir() / "plugins"
 
 
+def get_tenants_directory():
+    return get_icav2_plugins_home_dir() / "tenants"


### PR DESCRIPTION
Added the tenant subcommand with the following features

```
Usage:
  icav2 tenants <command> <args...>

Plugin Commands:
    init                 Initialise a tenant and provide an API Key used for that tenant
    enter                Enter a tenant (updates users ICAV2_ACCESS_TOKEN env var)
    list                 List available tenants to enter
    set-default-project  Set the default project for a given tenant
    set-default-tenant   Set the default tenant

Flags:
  -h, --help   help for tenants

Global Flags:
  -t, --access-token string    JWT used to call rest service
  -o, --output-format string   output format (default "table")
  -s, --server-url string      server url to direct commands
  -k, --x-api-key string       api key used to call rest service

Use "icav2 tenants [command] --help" for more information about a command
```