### PR TITLE
Fix tenant switching to use the ICAV2_BASE_URL env var

### DIFF
--- a/src/plugins/subcommands/projectanalyses/gantt_plot.py
+++ b/src/plugins/subcommands/projectanalyses/gantt_plot.py
@@ -45,7 +45,7 @@ Options:
 
 Environment:
     ICAV2_ACCESS_TOKEN (optional, set as ~/.icav2/.session.ica.yaml if not set)
-    ICAV2_BASE_URL (optional, defaults to ica.illumina.com)
+    ICAV2_BASE_URL (optional, defaults to https://ica.illumina.com/ica/rest)
     ICAV2_PROJECT_ID (optional, set as ~/.icav2/.session.ica.yaml if not set)
 
 

--- a/src/plugins/subcommands/projectanalyses/get_step_logs.py
+++ b/src/plugins/subcommands/projectanalyses/get_step_logs.py
@@ -52,7 +52,7 @@ Options:
 
 Environment:
     ICAV2_ACCESS_TOKEN (optional, defaults to value in ~/.icav2/session.ica.yaml)
-    ICAV2_BASE_URL (optional, defaults to ica.illumina.com)
+    ICAV2_BASE_URL (optional, defaults to https://ica.illumina.com/ica/rest)
     ICAV2_PROJECT_ID (optional, defaults to value in ~/.icav2/session.ica.yaml)
 
 

--- a/src/plugins/subcommands/projectanalyses/list_steps.py
+++ b/src/plugins/subcommands/projectanalyses/list_steps.py
@@ -40,7 +40,7 @@ Options:
 
 Environment:
     ICAV2_ACCESS_TOKEN (optional, set as ~/.icav2/.session.ica.yaml if not set)
-    ICAV2_BASE_URL (optional, defaults to ica.illumina.com)
+    ICAV2_BASE_URL (optional, defaults to https://ica.illumina.com/ica/rest)
     ICAV2_PROJECT_ID (optional, set as ~/.icav2/.session.ica.yaml if not set)
 
 

--- a/src/plugins/subcommands/tenants/set_default_project.py
+++ b/src/plugins/subcommands/tenants/set_default_project.py
@@ -6,33 +6,18 @@ This means when tenants enter command is invoked the ICAV2_PROJECT_ID is added
 """
 
 
-import json
-import os
-import shutil
 from collections import OrderedDict
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Optional
-from getpass import getpass
-
-from invoke import Responder
-from fabric import Connection
 
 from ruamel.yaml import YAML
 
 from utils import is_uuid_format
 from utils.errors import InvalidArgumentError
-from utils.config_helpers import get_project_id, create_access_token_from_api_key, get_jwt_token_obj, \
-    get_project_name_from_project_id_curl, get_project_id_from_project_name_curl
-from utils.cwl_helpers import ZippedCWLWorkflow
-from utils.gh_helpers import download_zipped_workflow_from_github_release, get_release_repo_and_tag_from_release_url
-from utils.globals import ICAV2_DEFAULT_ANALYSIS_STORAGE_SIZE, ICAv2AnalysisStorageSize, ICAV2_ACCESS_TOKEN_AUDIENCE
+from utils.config_helpers import create_access_token_from_api_key, \
+    get_project_id_from_project_name_curl, get_icav2_base_url
 from utils.logger import get_logger
-from utils.plugin_helpers import get_plugins_directory, get_tenants_directory
-from utils.projectpipeline_helpers import get_analysis_storage_id_from_analysis_storage_size, create_params_xml
-import requests
-
-from urllib.parse import unquote
+from utils.plugin_helpers import get_tenants_directory
 
 from subcommands import Command
 
@@ -71,9 +56,6 @@ Example:
         self.tenant_access_token: Optional[str] = None
 
         self.project_id: Optional[str] = None
-
-        # Server url
-        self.server_url: Optional[str] = "ica.illumina.com"
 
         # Store the tenant namespace and id in the configuration yaml
         self.x_api_key: Optional[str] = None
@@ -129,7 +111,7 @@ Example:
             self.project_id = project_name_arg
         else:
             # Get project id from project name
-            self.project_id = get_project_id_from_project_name_curl(project_name_arg, self.tenant_access_token)
+            self.project_id = get_project_id_from_project_name_curl(get_icav2_base_url(), project_name_arg, self.tenant_access_token)
 
     def get_tenant_api_key(self) -> str:
         """

--- a/src/plugins/subcommands/tenants/set_default_tenant.py
+++ b/src/plugins/subcommands/tenants/set_default_tenant.py
@@ -27,7 +27,7 @@ from ruamel.yaml import YAML
 from utils import is_uuid_format
 from utils.errors import InvalidArgumentError
 from utils.config_helpers import get_project_id, create_access_token_from_api_key, get_jwt_token_obj, \
-    get_project_name_from_project_id_curl, get_project_id_from_project_name_curl
+    get_project_name_from_project_id_curl, get_project_id_from_project_name_curl, get_icav2_base_url
 from utils.cwl_helpers import ZippedCWLWorkflow
 from utils.gh_helpers import download_zipped_workflow_from_github_release, get_release_repo_and_tag_from_release_url
 from utils.globals import ICAV2_DEFAULT_ANALYSIS_STORAGE_SIZE, ICAv2AnalysisStorageSize, ICAV2_ACCESS_TOKEN_AUDIENCE
@@ -36,7 +36,7 @@ from utils.plugin_helpers import get_tenants_directory
 from utils.projectpipeline_helpers import get_analysis_storage_id_from_analysis_storage_size, create_params_xml
 import requests
 
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 from subcommands import Command
 
@@ -70,12 +70,10 @@ Example:
         self.tenant_config_file: Optional[Path] = None
         self.tenant_config_yaml_object: Optional[OrderedDict] = None
         self.tenant_session_file: Optional[Path] = None
+        self.server_url = None
 
         self.current_config_path: Optional[Path] = Path.home() / ".icav2" / "config.yaml"
         self.current_session_path: Optional[Path] = Path.home() / ".icav2" / ".session.ica.yaml"
-
-        # Server url
-        self.server_url: Optional[str] = "ica.illumina.com"
 
         # Store the tenant namespace and id in the configuration yaml
         self.x_api_key: Optional[str] = None
@@ -91,7 +89,7 @@ Example:
             self.read_current_config()
         else:
             self.current_config_yaml_object = {
-                "server-url": "ica.illumina.com",
+                "server-url": urlparse(get_icav2_base_url()).netloc,
                 "x-api-key": None,
                 "output-format": None,
                 "colormode": None

--- a/src/plugins/subcommands/tenants/tenants_init.py
+++ b/src/plugins/subcommands/tenants/tenants_init.py
@@ -4,11 +4,7 @@
 Initialise a tenant from an api key
 """
 
-import json
-import os
-import shutil
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Optional
 from getpass import getpass
 
@@ -16,17 +12,11 @@ from ruamel.yaml import YAML
 
 from utils import is_uuid_format
 from utils.errors import InvalidArgumentError
-from utils.config_helpers import get_project_id, create_access_token_from_api_key, get_jwt_token_obj, \
-    get_project_name_from_project_id_curl, get_project_id_from_project_name_curl
-from utils.cwl_helpers import ZippedCWLWorkflow
-from utils.gh_helpers import download_zipped_workflow_from_github_release, get_release_repo_and_tag_from_release_url
-from utils.globals import ICAV2_DEFAULT_ANALYSIS_STORAGE_SIZE, ICAv2AnalysisStorageSize, ICAV2_ACCESS_TOKEN_AUDIENCE
+from utils.config_helpers import create_access_token_from_api_key, get_jwt_token_obj, \
+    get_project_name_from_project_id_curl, get_project_id_from_project_name_curl, get_icav2_base_url
+from utils.globals import ICAV2_ACCESS_TOKEN_AUDIENCE
 from utils.logger import get_logger
-from utils.plugin_helpers import get_plugins_directory, get_tenants_directory
-from utils.projectpipeline_helpers import get_analysis_storage_id_from_analysis_storage_size, create_params_xml
-import requests
-
-from urllib.parse import unquote
+from utils.plugin_helpers import get_tenants_directory
 
 from subcommands import Command
 
@@ -65,7 +55,7 @@ Example:
         self.access_token: Optional[str] = None
         self.tenant_namespace: Optional[str] = None
         self.tenant_id: Optional[str] = None
-        self.server_url: Optional[str] = "ica.illumina.com"
+        self.server_url: Optional[str] = None  # "ica.illumina.com"
 
         # Add in the project id and name
         self.project_id: Optional[str] = None
@@ -91,9 +81,9 @@ Example:
 
         # Use the access token to collect the project name if set
         if self.project_id is not None:
-            self.project_name = get_project_name_from_project_id_curl(self.project_id, self.access_token)
+            self.project_name = get_project_name_from_project_id_curl(get_icav2_base_url(), self.project_id, self.access_token)
         elif self.project_name is not None:
-            self.project_id = get_project_id_from_project_name_curl(self.project_name, self.access_token)
+            self.project_id = get_project_id_from_project_name_curl(get_icav2_base_url(), self.project_name, self.access_token)
 
         # Write out configuration yaml to file
         self.write_session_file()

--- a/src/plugins/utils/config_helpers.py
+++ b/src/plugins/utils/config_helpers.py
@@ -18,8 +18,9 @@ from datetime import datetime
 
 from jwt import decode, InvalidTokenError
 
-from utils.globals import ICAV2_SESSION_FILE_PATH, ICAV2_ACCESS_TOKEN_AUDIENCE, \
-    DEFAULT_ICAV2_BASE_URL, ICAV2_SESSION_FILE_ACCESS_TOKEN_KEY, ICAV2_SESSION_FILE_PROJECT_ID_KEY
+from utils.globals import ICAV2_CONFIG_FILE_PATH, ICAV2_SESSION_FILE_PATH, ICAV2_ACCESS_TOKEN_AUDIENCE, \
+    DEFAULT_ICAV2_BASE_URL, ICAV2_SESSION_FILE_ACCESS_TOKEN_KEY, ICAV2_SESSION_FILE_PROJECT_ID_KEY, \
+    ICAV2_CONFIG_FILE_SERVER_URL_KEY
 from utils.logger import get_logger
 from libica.openapi.v2 import Configuration, ApiClient, ApiException
 from typing import Optional, List
@@ -283,7 +284,7 @@ def create_access_token_from_api_key(api_key: str) -> str:
     get_api_key_returncode, get_api_key_stdout, get_api_key_stderr = run_subprocess_proc(
         [
             "curl", "--fail", "--silent", "--location", "--show-error",
-            "--url", "https://ica.illumina.com/ica/rest/api/tokens",
+            "--url", f"{get_libicav2_configuration().host}/api/tokens",
             "--header", "Accept: application/vnd.illumina.v3+json",
             "--header", f"X-API-Key: {api_key}",
             "--data", ""
@@ -299,7 +300,7 @@ def create_access_token_from_api_key(api_key: str) -> str:
     return json.loads(get_api_key_stdout).get("token")
 
 
-def get_project_id_from_project_name_curl(project_name: str, access_token: str) -> str:
+def get_project_id_from_project_name_curl(base_url: str, project_name: str, access_token: str) -> str:
     """
     Quick use of curl when the access token is not yet set in the configuration file (tenants init)
     Args:
@@ -315,7 +316,7 @@ def get_project_id_from_project_name_curl(project_name: str, access_token: str) 
             "--request", "GET",
             "--header", "Accept: application/vnd.illumina.v3+json",
             "--header", f"Authorization: Bearer {access_token}",
-            "--url", "https://ica.illumina.com/ica/rest/api/projects/"
+            "--url", f"{base_url}/api/projects/"
         ],
         capture_output=True
     )
@@ -335,7 +336,7 @@ def get_project_id_from_project_name_curl(project_name: str, access_token: str) 
     raise ValueError
 
 
-def get_project_name_from_project_id_curl(project_id: str, access_token: str) -> str:
+def get_project_name_from_project_id_curl(base_url, project_id: str, access_token: str) -> str:
     """
     Quick use of curl when the access token is not yet set in the configuration file (tenants init)
     Args:
@@ -351,7 +352,7 @@ def get_project_name_from_project_id_curl(project_id: str, access_token: str) ->
             "--request", "GET",
             "--header", "Accept: application/vnd.illumina.v3+json",
             "--header", f"Authorization: Bearer {access_token}",
-            "--url", f"https://ica.illumina.com/ica/rest/api/projects/{project_id}"
+            "--url", f"{base_url}/api/projects/{project_id}"
         ],
         capture_output=True
     )

--- a/src/plugins/utils/cwl_helpers.py
+++ b/src/plugins/utils/cwl_helpers.py
@@ -285,7 +285,7 @@ class ZippedCWLWorkflow:
             "--header", "Accept: application/vnd.illumina.v3+json",
             "--header", f"Authorization: Bearer {configuration.access_token}",
             "--header", "Content-Type: multipart/form-data",
-            "--url", f"https://ica.illumina.com/ica/rest/api/projects/{project_id}/pipelines:createCwlPipeline",
+            "--url", f"{configuration.host}/api/projects/{project_id}/pipelines:createCwlPipeline",
             "--form", f"code={workflow_code}",
             "--form", f"description={workflow_description}",
             "--form", f"workflowCwlFile=@{self.cwl_file_path};filename=workflow.cwl",

--- a/src/plugins/utils/globals.py
+++ b/src/plugins/utils/globals.py
@@ -8,9 +8,11 @@ from enum import Enum
 
 DEFAULT_ICAV2_BASE_URL = "https://ica.illumina.com/ica/rest"
 
+ICAV2_CONFIG_FILE_SERVER_URL_KEY = "server-url"
 ICAV2_SESSION_FILE_ACCESS_TOKEN_KEY = "access-token"
 ICAV2_SESSION_FILE_PROJECT_ID_KEY = "project-id"
 
+ICAV2_CONFIG_FILE_PATH = "{HOME}/.icav2/config.yaml"
 ICAV2_SESSION_FILE_PATH = "{HOME}/.icav2/.session.ica.yaml"
 
 ICAV2_ACCESS_TOKEN_AUDIENCE = "ica"

--- a/src/plugins/utils/projectpipeline_helpers.py
+++ b/src/plugins/utils/projectpipeline_helpers.py
@@ -438,7 +438,7 @@ def create_download_url(project_id: str, data_id: str) -> str:
         "curl",
         "--fail", "--silent", "--location",
         "--request", "POST",
-        "--url", f"https://ica.illumina.com/ica/rest/api/projects/{project_id}/data/{data_id}:createDownloadUrl",
+        "--url", f"{configuration.host}/api/projects/{project_id}/data/{data_id}:createDownloadUrl",
         "--header", "Accept: application/vnd.illumina.v3+json",
         "--header", f"Authorization: Bearer {configuration.access_token}",
         "--data", ""
@@ -523,7 +523,7 @@ def get_activation_id(project_id: str, pipeline_id: str, input_json: Dict,
         "curl",
         "--fail", "--silent", "--location",
         "--request", "POST",
-        "--url", "https://ica.illumina.com/ica/rest/api/activationCodes:findBestMatchingForCwl",
+        "--url", f"{configuration.host}/api/activationCodes:findBestMatchingForCwl",
         "--header", "Accept: application/vnd.illumina.v3+json",
         "--header", f"Authorization: Bearer {icav2_access_token}",
         "--header", "Content-Type: application/vnd.illumina.v3+json",
@@ -717,7 +717,7 @@ def get_cwl_analysis_input_json(project_id: str, analysis_id: str):
         "curl",
         "--fail", "--silent", "--location",
         "--request", "GET",
-        "--url", f"https://ica.illumina.com/ica/rest/api/projects/{project_id}/analyses/{analysis_id}/cwl/inputJson",
+        "--url", f"{configuration.host}/api/projects/{project_id}/analyses/{analysis_id}/cwl/inputJson",
         "--header", "Accept: application/vnd.illumina.v3+json",
         "--header", f"Authorization: Bearer {configuration.access_token}"
     ]
@@ -744,7 +744,7 @@ def get_cwl_analysis_output_json(project_id: str, analysis_id: str):
         "curl",
         "--fail", "--silent", "--location",
         "--request", "GET",
-        "--url", f"https://ica.illumina.com/ica/rest/api/projects/{project_id}/analyses/{analysis_id}/cwl/outputJson",
+        "--url", f"{configuration.host}/api/projects/{project_id}/analyses/{analysis_id}/cwl/outputJson",
         "--header", "Accept: application/vnd.illumina.v3+json",
         "--header", f"Authorization: Bearer {configuration.access_token}"
     ]


### PR DESCRIPTION
Use ICAV2_BASE_URL env var to determine ica url host.  

Fallback on server-url in config yaml. 

'tenants-enter' also exports ICAV2_BASE_URL