### PR TITLE
Removed reliance on assumed server url for session file

### DIFF
--- a/src/plugins/subcommands/tenants/set_default_tenant.py
+++ b/src/plugins/subcommands/tenants/set_default_tenant.py
@@ -39,6 +39,7 @@ import requests
 from urllib.parse import unquote, urlparse
 
 from subcommands import Command
+from utils.tenant_helpers import get_session_file_path_from_config_file
 
 logger = get_logger()
 
@@ -73,7 +74,7 @@ Example:
         self.server_url = None
 
         self.current_config_path: Optional[Path] = Path.home() / ".icav2" / "config.yaml"
-        self.current_session_path: Optional[Path] = Path.home() / ".icav2" / ".session.ica.yaml"
+        self.current_session_path: Optional[Path] = get_session_file_path_from_config_file(self.current_config_path)
 
         # Store the tenant namespace and id in the configuration yaml
         self.x_api_key: Optional[str] = None
@@ -119,7 +120,7 @@ Example:
 
         # Set the tenant session and config files
         self.tenant_config_file = self.tenant_path / "config.yaml"
-        self.tenant_session_file = self.tenant_path / ".session.ica.yaml"
+        self.tenant_session_file = get_session_file_path_from_config_file(self.tenant_config_file)
 
     def read_tenant_config(self):
         """

--- a/src/plugins/subcommands/tenants/tenants_init.py
+++ b/src/plugins/subcommands/tenants/tenants_init.py
@@ -19,6 +19,7 @@ from utils.logger import get_logger
 from utils.plugin_helpers import get_tenants_directory
 
 from subcommands import Command
+from utils.tenant_helpers import get_session_file_path_from_config_file
 
 logger = get_logger()
 
@@ -93,8 +94,12 @@ Example:
             self.project_id = get_project_id_from_project_name_curl(get_icav2_base_url(), self.project_name, self.access_token)
 
         # Write out configuration yaml to file
-        self.write_session_file()
         self.write_config_file()
+
+        # Now define the session file
+        self.tenant_session_file = get_session_file_path_from_config_file(self.tenant_config_file)
+        self.write_session_file()
+
 
     def write_session_file(self):
         yaml = YAML()
@@ -144,5 +149,4 @@ Example:
 
         # Set the tenant session and config files
         self.tenant_config_file = self.tenant_path / "config.yaml"
-        self.tenant_session_file = self.tenant_path / ".session.ica.yaml"
 

--- a/src/plugins/utils/config_helpers.py
+++ b/src/plugins/utils/config_helpers.py
@@ -69,7 +69,8 @@ def get_session_file_path() -> Path:
     :return:
     """
     session_file_path: Path = Path(ICAV2_SESSION_FILE_PATH.format(
-        HOME=os.environ["HOME"]
+        HOME=os.environ["HOME"],
+        server_url_midfix=get_icav2_base_url().netloc.split(".")[0]
     ))
 
     if not session_file_path.is_file():

--- a/src/plugins/utils/globals.py
+++ b/src/plugins/utils/globals.py
@@ -13,7 +13,7 @@ ICAV2_SESSION_FILE_ACCESS_TOKEN_KEY = "access-token"
 ICAV2_SESSION_FILE_PROJECT_ID_KEY = "project-id"
 
 ICAV2_CONFIG_FILE_PATH = "{HOME}/.icav2/config.yaml"
-ICAV2_SESSION_FILE_PATH = "{HOME}/.icav2/.session.ica.yaml"
+ICAV2_SESSION_FILE_PATH = "{HOME}/.icav2/.session.{server_url_prefix}.yaml"
 
 ICAV2_ACCESS_TOKEN_AUDIENCE = "ica"
 

--- a/src/plugins/utils/tenant_helpers.py
+++ b/src/plugins/utils/tenant_helpers.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+"""
+Help out tenant commands
+"""
+from pathlib import Path
+from urllib.parse import urlparse
+
+from ruamel.yaml import YAML
+
+from utils.config_helpers import get_icav2_base_url
+from utils.logger import get_logger
+
+logger = get_logger()
+
+
+def get_tenant_api_key_from_config_file(tenant_config_file: Path) -> str:
+    """
+    Get the tenant api key
+    Returns:
+
+    """
+    yaml = YAML()
+
+    with open(tenant_config_file, "r") as file_h:
+        return yaml.load(file_h).get("x-api-key")
+
+
+def get_server_url_from_config_file(tenant_config_file: Path) -> str:
+    """
+    Get the server api key
+    Returns:
+
+    """
+    yaml = YAML()
+
+    with open(tenant_config_file, "r") as file_h:
+        return yaml.load(file_h).get("server-url", urlparse(get_icav2_base_url()).netloc)
+
+
+def get_session_file_path_from_config_file(tenant_config_file: Path) -> Path:
+    server_url = get_server_url_from_config_file(tenant_config_file)
+
+    return tenant_config_file.parent / f".session.{server_url.split('.')[0]}.yaml"


### PR DESCRIPTION
Don't assume session file is named .session.ica.yaml, collect the 'ica' as the prefix for the server url