### PR TITLE
fix install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,7 @@ ICAV2_CLI_PLUGINS_HOME="$HOME/.icav2-cli-plugins"
 PLUGIN_VERSION="__PLUGIN_VERSION__"
 LIBICA_VERSION="__LIBICA_VERSION__"
 YQ_VERSION="4.18.1"
+PYTHON_VERSION="3.10"
 
 ###########
 # Functions
@@ -108,6 +109,29 @@ check_yq_version() {
     return 1
   fi
 }
+
+get_python_version(){
+  # Input: python3 --version
+  # Python 3.10.12
+  # Output: 3.10.12
+  python3 --version 2>/dev/null | cut -d' ' -f2
+}
+
+check_python_version() {
+  : '
+  Make sure at the latest conda version
+  '
+  if ! verlte "${PYTHON_VERSION}" "$(get_python_version)"; then
+    echo_stderr "Your python version is too old"
+    echo_stderr "icav2 cli plugins requires python 3.10 or later"
+    echo_stderr "You may wish to try"
+    echo_stderr "conda create --name python3.10 python=3.10"
+    echo_stderr "conda activate python3.10"
+    echo_stderr "bash install.sh"
+    return 1
+  fi
+}
+
 
 get_user_shell(){
   : '
@@ -200,6 +224,12 @@ fi
 
 if ! check_yq_version; then
   echo_stderr "Please update your version of yq and then rerun the installation"
+  print_help
+  exit 1
+fi
+
+if ! check_python_version; then
+  echo_stderr "Please update your version of python3 and then rerun the installation"
   print_help
   exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -129,6 +129,8 @@ check_curl_version() {
   '
   if ! verlte "${CURL_VERSION}" "$(get_curl_version)"; then
     echo_stderr "Your curl version is too old"
+  fi
+}
 
 get_python_version(){
   # Input: python3 --version
@@ -252,7 +254,8 @@ if ! check_curl_version; then
   echo_stderr "Please update your version of curl to ${CURL_VERSION} or later and then rerun the installation"
   print_help
   exit 1
-  
+fi
+
 if ! check_python_version; then
   echo_stderr "Please update your version of python3 and then rerun the installation"
   print_help

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,7 @@ ICAV2_CLI_PLUGINS_HOME="$HOME/.icav2-cli-plugins"
 PLUGIN_VERSION="__PLUGIN_VERSION__"
 LIBICA_VERSION="__LIBICA_VERSION__"
 YQ_VERSION="4.18.1"
+CURL_VERSION="7.76.0"
 PYTHON_VERSION="3.10"
 
 ###########
@@ -110,6 +111,25 @@ check_yq_version() {
   fi
 }
 
+get_curl_version(){
+  # Input:
+  #   curl 7.81.0 (x86_64-pc-linux-gnu) libcurl/7.81.0 OpenSSL/3.0.2 zlib/1.2.11 brotli/1.0.9 zstd/1.4.8 libidn2/2.3.2 libpsl/0.21.0 (+libidn2/2.3.2) libssh/0.9.6/openssl/zlib nghttp2/1.43.0 librtmp/2.3 OpenLDAP/2.5.16
+  #   Release-Date: 2022-01-05
+  #   Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
+  #   Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM NTLM_WB PSL SPNEGO SSL TLS-SRP UnixSockets zstd
+  # Output: 7.81.0
+  curl --version 2>/dev/null | \
+  head -n1 | \
+  cut -d' ' -f2
+}
+
+check_curl_version() {
+  : '
+  Make sure at the latest conda version
+  '
+  if ! verlte "${CURL_VERSION}" "$(get_curl_version)"; then
+    echo_stderr "Your curl version is too old"
+
 get_python_version(){
   # Input: python3 --version
   # Python 3.10.12
@@ -131,7 +151,6 @@ check_python_version() {
     return 1
   fi
 }
-
 
 get_user_shell(){
   : '
@@ -228,11 +247,18 @@ if ! check_yq_version; then
   exit 1
 fi
 
+
+if ! check_curl_version; then
+  echo_stderr "Please update your version of curl to ${CURL_VERSION} or later and then rerun the installation"
+  print_help
+  exit 1
+  
 if ! check_python_version; then
   echo_stderr "Please update your version of python3 and then rerun the installation"
   print_help
   exit 1
 fi
+
 
 # Steps get configuration / icav2 plugins home directory
 # TODO - hardcode as $HOME/.icav2-cli-plugins/ for now

--- a/install.sh
+++ b/install.sh
@@ -333,6 +333,8 @@ rsync --delete --archive \
   "$(get_this_path)/shell_functions/" "${ICAV2_CLI_PLUGINS_HOME}/shell_functions/"
 # Update shell function
 sed -i "s/__PLUGIN_VERSION__/${PLUGIN_VERSION}/" "${ICAV2_CLI_PLUGINS_HOME}/shell_functions/icav2.sh"
+sed -i "s/__LIBICA_VERSION__/${LIBICA_VERSION}/" "${ICAV2_CLI_PLUGINS_HOME}/shell_functions/icav2.sh"
+
 
 ######################
 # LINK PANDOC BINARY

--- a/src/plugins/requirements.txt
+++ b/src/plugins/requirements.txt
@@ -2,7 +2,7 @@
 beautifulsoup4==4.11.1
 cwl_utils==0.21
 docopt==0.6.2
-libica==2.2.1
+libica==2.3.0
 mdutils==1.4.0
 pandas==1.5.2
 PyJWT==2.6.0

--- a/src/plugins/subcommands/__init__.py
+++ b/src/plugins/subcommands/__init__.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-
+import os
 import sys
+from pathlib import Path
+from typing import Union, List, Optional, Tuple, Type
 
 from docopt import docopt
+
+from utils import to_lower_camel_case
 from utils.errors import InvalidArgumentError
 from utils.logger import get_logger
 from utils.docopt_helpers import clean_multi_args
@@ -71,6 +75,193 @@ class Command:
         :return:
         """
         raise NotImplementedError
+
+    def _get_arg_in_input_yaml_arg_name(
+            self,
+            arg_name: str,
+            input_yaml_data: dict,
+            required: bool,
+            arg_type: Union[Type[str] | Type[Path] | Type[List]],
+            attr_name: str,
+            yaml_key: Optional[str] = None,
+            env: Optional[str] =None
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Sub-function of set_arg_from_in_input_yaml_and_cli, handles when we have multiple options for the arg_name
+        We want to iterate through CLI first, then YAML, then ENV
+        But that's not that easy, so instead we return a dict containing the value and the source
+        :param arg_name:
+        :param input_yaml_data:
+        :param required:
+        :param arg_type:
+        :param attr_name:
+        :param yaml_key:
+        :return:
+        """
+        # This might mean handling str in a subfunction and calling the subfunction over the list.
+        arg_value = self.args.get(arg_name, None)
+        arg_source = "cli"
+
+        if yaml_key is None:
+            yaml_key = attr_name
+
+        if arg_value is None and env is not None:
+            arg_value = os.environ.get(env, None)
+            arg_source = "env"
+
+        # Yaml keys can be camel case
+        yaml_keys = [yaml_key, to_lower_camel_case(yaml_key)]
+
+        # Handle arg_type is string first
+        if arg_type in [str, Path]:
+            # Check if not in the cli or in env
+            if arg_value is not None:
+                pass
+
+            # Check if any of the keys
+            elif any([yaml_key in input_yaml_data.keys() for yaml_key in yaml_keys]):
+                yaml_key = next(
+                    filter(
+                        lambda key: key in input_yaml_data.keys(),
+                        yaml_keys
+                    )
+                )
+
+                arg_value = input_yaml_data[yaml_key]
+                arg_source = "yaml"
+
+            # Check if argument is required
+            elif required:
+                logger.error(f"Argument '{arg_name}' is required but not found in input yaml or cli")
+                raise InvalidArgumentError
+
+            # Handle if arg value is None
+            # Don't cast None type object to a string
+            if arg_value is None:
+                return None, None
+
+            # Cast from string to Path if need be
+            if not isinstance(arg_value, arg_type):
+                arg_value = arg_type(arg_value)
+
+            # Set attribute
+            return arg_value, arg_source
+
+        # FIXME - wrong spot for this
+        if arg_type == List:
+            # Append if in both
+            values_in_yaml_and_cli = []
+
+            if arg_value is not None:
+                values_in_yaml_and_cli.extend(arg_value)
+
+            if yaml_key in input_yaml_data.keys():
+                values_in_yaml_and_cli.extend(input_yaml_data.get(yaml_key))
+
+            if required and len(values_in_yaml_and_cli) == 0:
+                logger.error(f"{arg_name} not specified in the input yaml or on the CLI")
+                raise InvalidArgumentError
+
+            self.__setattr__(attr_name, values_in_yaml_and_cli)
+
+    def set_arg_from_in_input_yaml_and_cli(
+            self,
+            arg_name: Union[str | List],
+            input_yaml_data: dict,
+            required: bool,
+            arg_type: Union[Type[str] | Type[Path] | Type[List]],
+            attr_name: Optional[str] = None,
+            yaml_key: Optional[Union[str | List]] = None,
+            env: Optional[str] = None
+    ):
+        """
+        For a given argument, check that it's been specified in the input yaml or the cli (and return the value of the argument).
+
+        The CLI argument takes precendence over the environment variable, which takes precedence over the input yaml argument.
+
+        We assume that the argument names are identical, swapping '-' for '_' with cli and yaml respectively.
+
+        One may also look for multiple arguments with the first argument in the list taking preference.
+        In this case, if the second argument is found on the cli but the first argument is found in the yaml,
+        the cli still takes preference
+
+        If the argument is not found in either the input yaml or the cli, then we raise an error.
+
+        We also allow for custom attribute names to map between yaml and cli arguments.
+
+        :param arg_name:
+        :param input_yaml_data:
+        :param required:
+        :param arg_type:
+        :param attr_name:
+        :param yaml_key:
+        :param env:
+        :return:
+        """
+        # If yaml_key, or attr_name is set, use those instead
+        if attr_name is None:
+            # Convert --arg-name to arg_name
+            attr_name = arg_name.lstrip("-").replace("-", "_")
+
+        # Get cli arg value and attribute names for yaml
+        if isinstance(arg_name, str):
+            arg_value, arg_source = self._get_arg_in_input_yaml_arg_name(
+                arg_name=arg_name,
+                input_yaml_data=input_yaml_data,
+                required=required,
+                arg_type=arg_type,
+                attr_name=attr_name,
+                yaml_key=yaml_key,
+                env=env,
+            )
+
+        elif isinstance(arg_name, List):
+            arg_values_by_source = {}
+            arg_value = None
+            arg_source = None
+
+            for iter_, arg_name_iter in enumerate(arg_name):
+                if isinstance(yaml_key, List):
+                    try:
+                        yaml_key_val = yaml_key[iter_]
+                    except IndexError:
+                        logger.error("Must specify a yaml key for each arg_name in the list if yaml_key is a list")
+                        raise IndexError
+                else:
+                    yaml_key_val = yaml_key
+
+                # Get arg value and source for this iter
+                arg_value, arg_source = self._get_arg_in_input_yaml_arg_name(
+                    arg_name=arg_name_iter,
+                    input_yaml_data=input_yaml_data,
+                    # May be multiple options, check at the end if required and fail if no value is found
+                    required=False,
+                    arg_type=arg_type,
+                    attr_name=attr_name,
+                    yaml_key=yaml_key_val,
+                    env=env,
+                )
+
+                # Only return the first value for each source
+                if arg_source not in arg_values_by_source.keys():
+                    arg_values_by_source[arg_source] = arg_value
+
+            for arg_source_iter in ["cli", "env", "yaml"]:
+                if arg_source_iter in arg_values_by_source.keys():
+                    arg_value = arg_values_by_source[arg_source_iter]
+                    break
+            else:
+                arg_value = None
+        else:
+            logger.error(f"arg_name type of '{type(arg_name)}' not supported, must be a list or str")
+            raise TypeError
+
+        # Set attribute
+        # Don't overwrite if attribute already exists though
+        if arg_value is None and required:
+            logger.error(f"Required {('one of' + ','.join(arg_name)) if isinstance(arg_name, List) else arg_name} in either cli or input yaml but not found")
+        if arg_value is not None and getattr(self, attr_name, None) is None:
+            self.__setattr__(attr_name, arg_value)
 
     def __call__(self):
         raise NotImplementedError

--- a/src/plugins/subcommands/projectpipelines/launch_cwl_wes.py
+++ b/src/plugins/subcommands/projectpipelines/launch_cwl_wes.py
@@ -284,6 +284,14 @@ Example:
             else:  # Assume it's a path
                 if not self.output_parent_folder_arg.endswith("/"):
                     self.output_parent_folder_arg += "/"
+
+                # Update placeholders before checking if the path exists
+                self.output_parent_folder_arg = (
+                    self.input_launch_json.engine_parameters.populate_placeholders_in_output_path(
+                        self.output_parent_folder_arg
+                    )
+                )
+
                 # Create directory if it doesn't exist
                 if not check_is_directory(
                         project_id=self.project_id,
@@ -309,6 +317,12 @@ Example:
         if self.analysis_output_uri_path_arg is not None:
             if is_uri_format(self.analysis_output_uri_path_arg):
                 analysis_output_project_id, analysis_output_project_path = unpack_icav2_uri(self.analysis_output_uri_path_arg)
+                # Update placeholders before checking if the path exists
+                analysis_output_project_path = (
+                    self.input_launch_json.engine_parameters.populate_placeholders_in_output_path(
+                        analysis_output_project_path
+                    )
+                )
                 self.analysis_output = [
                     AnalysisOutputMapping(
                         source_path="out/",

--- a/src/plugins/utils/__init__.py
+++ b/src/plugins/utils/__init__.py
@@ -1,5 +1,6 @@
 import re
 from typing import Dict, Any
+from urllib.parse import urlparse
 from uuid import UUID
 
 version = "2.10.0"
@@ -8,6 +9,17 @@ version = "2.10.0"
 # Miscellaneous functions that don't go anywhere
 def camel_to_snake_case(camel_case: str) -> str:
     return re.sub(r'(?<!^)(?=[A-Z])', '_', camel_case).lower()
+
+
+def snake_to_camel_case(snake_case: str) -> str:
+    return ''.join(word.title() for word in snake_case.split('_'))
+
+
+def to_lower_camel_case(snake_str):
+    # We capitalize the first letter of each component except the first one
+    # with the 'capitalize' method and join them together.
+    camel_string = snake_to_camel_case(snake_str)
+    return snake_str[0].lower() + camel_string[1:]
 
 
 def sanitise_dict_keys(input_dict: Dict) -> Dict:
@@ -22,6 +34,19 @@ def sanitise_dict_keys(input_dict: Dict) -> Dict:
 def is_uuid_format(project_id: str) -> bool:
     try:
         _ = UUID(project_id, version=4)
+        return True
+    except ValueError:
+        return False
+
+
+def is_uri_format(uri_str: str) -> bool:
+    """
+    Determine if the string is a valid URI
+    :param uri_str:
+    :return:
+    """
+    try:
+        _ = urlparse(uri_str)
         return True
     except ValueError:
         return False

--- a/src/plugins/utils/bundle_helpers.py
+++ b/src/plugins/utils/bundle_helpers.py
@@ -297,8 +297,8 @@ def add_pipeline_to_bundle(bundle_id: str, pipeline_id: str) -> Optional[bool]:
             logger.info(f"Pipeline {pipeline_id} already linked to bundle {bundle_id}")
             return False
         logger.error(f"Got the following error while trying to link pipeline {pipeline_id} to bundle {bundle_id}")
-        if json.loads(curl_stdout).get("status", None) == 400:
-            logger.info(f"Error detail is '{json.loads(curl_stdout).get('detail', None)}'")
+        logger.info(f"Error detail is '{json.loads(curl_stdout).get('detail', None)}'")
+        logger.error(json.loads(curl_stdout))
         logger.error(curl_stderr)
         raise ChildProcessError
 
@@ -353,8 +353,11 @@ def add_data_to_bundle(bundle_id: str, data_id: str, data_region_id: Optional[st
             logger.info(f"Data {data_id} already linked to bundle {bundle_id}")
             return False
         logger.error(f"Got the following error while trying to link data {data_id} to bundle {bundle_id}")
-        if json.loads(curl_stdout).get("status", None) == 400:
-            logger.info(f"Error detail is '{json.loads(curl_stdout).get('detail', None)}'")
+        logger.info(f"Error detail is '{json.loads(curl_stdout).get('detail', None)}'")
+        if json.loads(curl_stdout).get("status", None) == 403:
+            logger.error(f"User does not have permission to 'link-out' this data {data_id}.")
+            logger.error(f"Please ensure user has 'download' permissions to a project where this data either exists or has been linked to")
+        logger.error(json.loads(curl_stdout))
         logger.error(curl_stderr)
         raise ChildProcessError
 

--- a/src/plugins/utils/cwl_helpers.py
+++ b/src/plugins/utils/cwl_helpers.py
@@ -296,11 +296,8 @@ class ZippedCWLWorkflow:
 
         configuration = get_libicav2_configuration()
 
-        workflow_code = "--".join([
-            self.zipped_cwl_file_path.stem.replace(".", "_"),
-            datetime.today().strftime("%Y%m%d%H%M%S"),
-            self.get_md5sum_from_packed_dict()
-        ])
+        workflow_code = self.zipped_cwl_file_path.stem.replace(".", "_")
+        
         curl_command_list = [
             "curl",
             # "--fail", "--silent", "--location",

--- a/src/plugins/utils/projectpipeline_helpers.py
+++ b/src/plugins/utils/projectpipeline_helpers.py
@@ -1,10 +1,13 @@
+from datetime import datetime
 import json
 from json import JSONDecodeError
 from pathlib import Path
+import re
 from typing import Dict, Optional, List, Any, Union, Tuple
 from urllib.parse import urlparse
 import sys
 import contextlib
+from uuid import uuid4
 
 from libica.openapi.v2.model.analysis import Analysis
 
@@ -91,7 +94,7 @@ class ICAv2EngineParameters:
             cwltool_overrides: Dict,
             # stream_all_files, stream_all_directories
     ):
-        # Initiliase parameters
+        # Initialise parameters
         # pipeline, outputs etc can be inherited from the cli and updated in the check args instead
         # Only the engine parameters that are cannot be set in the CLI are set here
         self.pipeline_id: Optional[str] = None
@@ -104,6 +107,15 @@ class ICAv2EngineParameters:
         self.cwltool_overrides: Dict = cwltool_overrides
         # self.stream_all_files: Optional[bool] = stream_all_files
         # self.stream_all_directories: Optional[bool] = stream_all_directories
+
+        # Set placeholders
+        current_utc_time = datetime.utcnow()
+        self.placeholder_dict: Dict = {
+            "__DATE_STR__": current_utc_time.strftime("%Y%m%d"),
+            "__TIME_STR__": current_utc_time.strftime("%H%M%S"),
+            "__UUID8_STR__": uuid4().hex[:8],
+            "__UUID16_STR__": uuid4().hex[:16],
+        }
 
     def update_engine_parameter(self, attribute_name: str, value: Any):
         self.__setattr__(attribute_name, value)
@@ -121,6 +133,17 @@ class ICAv2EngineParameters:
                 project_id, pipeline_id, input_json,
                 mount_list
             )
+
+    def populate_placeholders_in_output_path(self, analysis_path: str):
+        """
+        Populate placeholders in the output path
+        :param placeholder_dict:
+        :return:
+        """
+        return fill_placeholder_path(
+            analysis_path,
+            self.placeholder_dict
+        )
 
     # from_dict - read in input
     @classmethod
@@ -829,6 +852,23 @@ def release_pipeline(project_id: str, pipeline_id: str):
         raise ChildProcessError
 
     logger.info(f"Successfully released {pipeline_id}")
+
+
+def fill_placeholder_path(output_path_str: str, placeholder_dict):
+    """
+    Fill the analysisOutput or folder path with a placeholder.
+
+    Supported
+    :param output_path_str:
+    :param placeholder_dict:
+    :return:
+    """
+    for key_regex, replacement_value in placeholder_dict.items():
+        if not re.match(key_regex, output_path_str):
+            continue
+        output_path_str = re.sub(key_regex, replacement_value, output_path_str)
+
+    return output_path_str
 
 
 @contextlib.contextmanager

--- a/src/plugins/utils/projectpipeline_helpers.py
+++ b/src/plugins/utils/projectpipeline_helpers.py
@@ -399,12 +399,6 @@ def convert_icav2_uris_to_data_ids(input_obj: Union[str, int, bool, Dict, List])
                     logger.error("Got mismatch on data type and class for input object")
                     logger.error(f"Class of {input_obj.get('location')} is set to directory but found file id {data_id} instead")
 
-                # Mount folder at top of directory
-                if data_type == "FOLDER":
-                    # Folders can only be mounted at the top dir now
-                    # See https://github.com/umccr-illumina/ica_v2/issues/99
-                    mount_path = str(Path(mount_path).name) + "/"
-
                 # Set file to presigned url
                 if data_type == "FILE" and is_presign:
                     input_obj["location"] = create_download_url(owning_project_id, data_id)


### PR DESCRIPTION
- Capture 403 errors
- Check curl version is later than 7.76 (for --fail-with-body parameter)
- Check version of python3 is python3.10 or higher
- Find replace drop of libica version into shell function
- Bump libica to 2.3.0
- Revert folders to be mounted at the top of the scratch space
- Added analysis output option
- Workflow codes generated from github releases dont have datestamps
- start-cwl-wes now supports DATE_STR, UUID8, UUID16 and TIME_STR placeholders
- Fixed install script syntax closure
