### PR TITLE
[bump-version.sh] Bumped version in toml to '2.20.0'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,14 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = [
+    "setuptools>=61.0",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "icav2-cli-plugins"
 version = "2.20.0"
 authors = [
-  { name="Alexis Lucattini", email="alexis.lucattini@umccr.org" },
+    { name = "Alexis Lucattini", email = "alexis.lucattini@umccr.org" },
 ]
 description = "icav2-cli-plugins"
 readme = "Readme.md"
@@ -16,33 +18,31 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-
 dependencies = [
-  # Requirements created by pip-reqs
-  "beautifulsoup4 >= 4.11.1, < 5",
-  "cwl_utils >= 0.32, < 1",
-  "docopt >= 0.6.2, < 1",
-  "libica >= 2.3.0, < 3",
-  "mdutils >= 1.4.0, < 2",
-  "pandas >= 2.1.3, < 3",
-  "PyJWT >= 2.6.0, < 3",
-  "ruamel.yaml >= 0.18, < 0.19",
-  "requests >= 2.31.0, < 3",
-  "ruamel.base == 1.0.0",
-  "tabulate >= 0.9.0, < 1",
-  "verboselogs >= 1.7, < 2",
-  "websocket_client >= 1.4.2, < 2",
-  "cwltool >= 3.1.20231016170136, < 4",
-  "pandoc >= 2.3, < 3",
-  "humanfriendly >= 10.0, < 11",
-  "matplotlib >= 3.7.1, < 4",
-  "invoke >= 2.0.0, < 3",
-  "fabric >= 3.0.0, < 4",
-  "deepdiff >= 6.7.1, < 7"
+    "beautifulsoup4 >= 4.11.1, < 5",
+    "cwl_utils >= 0.32, < 1",
+    "docopt >= 0.6.2, < 1",
+    "libica >= 2.3.0, < 3",
+    "mdutils >= 1.4.0, < 2",
+    "pandas >= 2.1.3, < 3",
+    "PyJWT >= 2.6.0, < 3",
+    "ruamel.yaml >= 0.18, < 0.19",
+    "requests >= 2.31.0, < 3",
+    "ruamel.base == 1.0.0",
+    "tabulate >= 0.9.0, < 1",
+    "verboselogs >= 1.7, < 2",
+    "websocket_client >= 1.4.2, < 2",
+    "cwltool >= 3.1.20231016170136, < 4",
+    "pandoc >= 2.3, < 3",
+    "humanfriendly >= 10.0, < 11",
+    "matplotlib >= 3.7.1, < 4",
+    "invoke >= 2.0.0, < 3",
+    "fabric >= 3.0.0, < 4",
+    "deepdiff >= 6.7.1, < 7",
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/umccr/icav2-cli-plugins"
+Homepage = "https://github.com/umccr/icav2-cli-plugins"
 "Bug Tracker" = "https://github.com/umccr/icav2-cli-plugins/issues"
 
 [project.scripts]
@@ -51,9 +51,8 @@ dependencies = [
 [project.optional-dependencies]
 pandoc = [
     "pypandoc==1.10",
-    "pypandoc_binary==1.10"
+    "pypandoc_binary==1.10",
 ]
 toml = [
-    "tomli_w >= 1.0.0, < 2"
+    "tomli_w >= 1.0.0, < 2",
 ]
-


### PR DESCRIPTION
## New commands
projectpipelines update (still a WIP but can update non main files for a draft pipeline)
Add placeholders in the output folder path
pipelines list-projects
pipelines check-ownership

## Upgrades
Upgrade to python3.11
Use pyproject.toml over rsync scripts in installation
Bumped libica version to 2.3.0
Reduce pipeline name length
Support using the 'out/' attribute for pipeline outputs (Rather than needing to use the parent folder id)